### PR TITLE
Use `Promise.allSettled` in `requestOrder`

### DIFF
--- a/src/features/orders/orderAPI.ts
+++ b/src/features/orders/orderAPI.ts
@@ -15,7 +15,7 @@ export async function requestOrder(
     signerToken,
     senderToken
   );
-  const orders = servers.map(async (server) => {
+  const orderPromises = servers.map(async (server) => {
     const order = await server.getSignerSideOrder(
       toAtomicString(senderAmount, 18),
       signerToken,
@@ -24,7 +24,11 @@ export async function requestOrder(
     );
     return order as any as LightOrder;
   });
-  return Promise.all(orders);
+  const orders = await Promise.allSettled(orderPromises);
+  const successfulOrders = orders
+    .filter((result) => result.status === "fulfilled")
+    .map((result) => (result as PromiseFulfilledResult<LightOrder>).value);
+  return successfulOrders;
 }
 
 export async function approveToken(


### PR DESCRIPTION
I noticed when looking over request code for aaaaaaaaaa's maker bot that if any server returns an error for an order, the entire `requestOrder` function would reject.

I've changed the code to use `Promise.allSettled` instead, then to filter out error responses, and return only valid orders.

Note that in the event all servers return an error, the promise returned by this function **will still resolve**, but with an empty array. I'm not sure whether this is desirable, or if we should check for this case and reject (my preference is empty array).

---
Brief typescript explanation (because it confused me at first):

- `Promise.allSettled` returns `PromiseSettledResult<T>`s which have just a `status` property  `("fulfilled"|"rejected")`. 
-`PromiseFulfilledResult<T>` extends this with `value: T` (resolve value)
-`PromiseRejectedResult` extends it with a `reason` property (assume `any` but will most likely be an error - it's the reject value).
- After filtering out any `PromiseSettledResult`s with `status: "rejected"` we know we're only left with `PromseFulfilledResult`s so we can safely cast.
