### PR TITLE
Select best order + test

### DIFF
--- a/src/features/orders/Orders.tsx
+++ b/src/features/orders/Orders.tsx
@@ -7,7 +7,7 @@ import {
   approve,
   request,
   take,
-  selectOrder,
+  selectBestOrder,
   selectOrdersStatus,
 } from "./ordersSlice";
 import { selectActiveTokens } from "../metadata/metadataSlice";
@@ -18,7 +18,7 @@ import TokenSelect from "../../components/TokenSelect/TokenSelect";
 import Button from "../../components/Button/Button";
 
 export function Orders() {
-  const order = useAppSelector(selectOrder);
+  const order = useAppSelector(selectBestOrder);
   const ordersStatus = useAppSelector(selectOrdersStatus);
   const dispatch = useAppDispatch();
   const activeTokens = useAppSelector(selectActiveTokens);

--- a/src/features/orders/ordersSlice.spec.ts
+++ b/src/features/orders/ordersSlice.spec.ts
@@ -1,4 +1,5 @@
-import ordersReducer, { OrdersState } from "./ordersSlice";
+import { RootState } from "../../app/store";
+import ordersReducer, { OrdersState, selectBestOrder } from "./ordersSlice";
 
 describe("orders reducer", () => {
   const initialState: OrdersState = {
@@ -7,5 +8,68 @@ describe("orders reducer", () => {
   };
   it("should handle initial state", () => {
     expect(ordersReducer(undefined, { type: "unknown" })).toEqual(initialState);
+  });
+
+  it("should select the best order", () => {
+    const ignoredOrderProps = {
+      expiry: "ignored",
+      nonce: "ignored",
+      r: "ignored",
+      s: "ignored",
+      v: "ignored",
+      senderToken: "0xa",
+      signerToken: "0xb",
+      signerWallet: "0xyou",
+      senderWallet: "0xme",
+    };
+    // @ts-ignore (don't need to populate entire rootstate)
+    let state: RootState = {
+      orders: {
+        ...initialState,
+        orders: [
+          {
+            ...ignoredOrderProps,
+            senderAmount: "1",
+            signerAmount: "5",
+          },
+          {
+            ...ignoredOrderProps,
+            senderAmount: "1",
+            signerAmount: "7",
+          },
+          {
+            ...ignoredOrderProps,
+            senderAmount: "1",
+            signerAmount: "3",
+          },
+        ],
+      },
+    };
+    expect(selectBestOrder(state).signerAmount).toBe("7");
+
+    // @ts-ignore (don't need to populate entire rootstate)
+    state = {
+      orders: {
+        ...initialState,
+        orders: [
+          {
+            ...ignoredOrderProps,
+            senderAmount: "6",
+            signerAmount: "7",
+          },
+          {
+            ...ignoredOrderProps,
+            senderAmount: "8",
+            signerAmount: "7",
+          },
+          {
+            ...ignoredOrderProps,
+            senderAmount: "10",
+            signerAmount: "7",
+          },
+        ],
+      },
+    };
+    expect(selectBestOrder(state).senderAmount).toBe("6");
   });
 });

--- a/src/features/orders/ordersSlice.spec.ts
+++ b/src/features/orders/ordersSlice.spec.ts
@@ -10,20 +10,20 @@ describe("orders reducer", () => {
     expect(ordersReducer(undefined, { type: "unknown" })).toEqual(initialState);
   });
 
-  it("should select the best order", () => {
-    const ignoredOrderProps = {
-      expiry: "ignored",
-      nonce: "ignored",
-      r: "ignored",
-      s: "ignored",
-      v: "ignored",
-      senderToken: "0xa",
-      signerToken: "0xb",
-      signerWallet: "0xyou",
-      senderWallet: "0xme",
-    };
+  const ignoredOrderProps = {
+    nonce: "ignored",
+    r: "ignored",
+    s: "ignored",
+    v: "ignored",
+    senderToken: "0xa",
+    signerToken: "0xb",
+    signerWallet: "0xyou",
+    senderWallet: "0xme",
+  };
+
+  it("should select the best signer side order", () => {
     // @ts-ignore (don't need to populate entire rootstate)
-    let state: RootState = {
+    const state: RootState = {
       orders: {
         ...initialState,
         orders: [
@@ -31,24 +31,29 @@ describe("orders reducer", () => {
             ...ignoredOrderProps,
             senderAmount: "1",
             signerAmount: "5",
+            expiry: "1",
           },
           {
             ...ignoredOrderProps,
             senderAmount: "1",
             signerAmount: "7",
+            expiry: "2",
           },
           {
             ...ignoredOrderProps,
             senderAmount: "1",
             signerAmount: "3",
+            expiry: "3",
           },
         ],
       },
     };
     expect(selectBestOrder(state).signerAmount).toBe("7");
+  });
 
+  it("should select the best sender side order", () => {
     // @ts-ignore (don't need to populate entire rootstate)
-    state = {
+    const state: RootState = {
       orders: {
         ...initialState,
         orders: [
@@ -56,20 +61,53 @@ describe("orders reducer", () => {
             ...ignoredOrderProps,
             senderAmount: "6",
             signerAmount: "7",
+            expiry: "1",
           },
           {
             ...ignoredOrderProps,
             senderAmount: "8",
             signerAmount: "7",
+            expiry: "2",
           },
           {
             ...ignoredOrderProps,
             senderAmount: "10",
             signerAmount: "7",
+            expiry: "3",
           },
         ],
       },
     };
     expect(selectBestOrder(state).senderAmount).toBe("6");
+  });
+
+  it("should select orders based on longest expiry if token amounts are equal", () => {
+    // @ts-ignore (don't need to populate entire rootstate)
+    const state: RootState = {
+      orders: {
+        ...initialState,
+        orders: [
+          {
+            ...ignoredOrderProps,
+            senderAmount: "7",
+            signerAmount: "7",
+            expiry: "1",
+          },
+          {
+            ...ignoredOrderProps,
+            senderAmount: "7",
+            signerAmount: "7",
+            expiry: "3",
+          },
+          {
+            ...ignoredOrderProps,
+            senderAmount: "7",
+            signerAmount: "7",
+            expiry: "2",
+          },
+        ],
+      },
+    };
+    expect(selectBestOrder(state).expiry).toBe("3");
   });
 });

--- a/src/features/orders/ordersSlice.ts
+++ b/src/features/orders/ordersSlice.ts
@@ -8,7 +8,7 @@ import {
   revertTransaction,
   declineTransaction,
 } from "../transactions/transactionActions";
-import { Transaction } from "ethers";
+import { BigNumber, Transaction } from "ethers";
 
 export interface OrdersState {
   orders: LightOrder[];
@@ -102,6 +102,28 @@ export const ordersSlice = createSlice({
 });
 
 export const { clear } = ordersSlice.actions;
-export const selectOrder = (state: RootState) => state.orders.orders[0];
+/**
+ * Sorts orders and returns the best. Note: Could be improved to cover the
+ * unlikely event that two makers produce exact same order, and could then
+ * take into account expiry.
+ */
+export const selectBestOrder = (state: RootState) =>
+  state.orders.orders.sort((a, b) => {
+    if (a.signerAmount === b.signerAmount) {
+      // Likely senderSide
+      // Sort orders by amount of senderToken sent (ascending).
+      const aAmount = BigNumber.from(a.senderAmount);
+      const bAmount = BigNumber.from(b.senderAmount);
+      if (bAmount.lt(aAmount)) return 1;
+      else return -1;
+    } else {
+      // Likely signerSide
+      // Sort orders by amount of signerToken received (descending).
+      const aAmount = BigNumber.from(a.signerAmount);
+      const bAmount = BigNumber.from(b.signerAmount);
+      if (bAmount.gt(aAmount)) return 1;
+      else return -1;
+    }
+  })[0];
 export const selectOrdersStatus = (state: RootState) => state.orders.status;
 export default ordersSlice.reducer;

--- a/src/features/orders/ordersSlice.ts
+++ b/src/features/orders/ordersSlice.ts
@@ -103,12 +103,18 @@ export const ordersSlice = createSlice({
 
 export const { clear } = ordersSlice.actions;
 /**
- * Sorts orders and returns the best. Note: Could be improved to cover the
- * unlikely event that two makers produce exact same order, and could then
- * take into account expiry.
+ * Sorts orders and returns the best order based on tokens received or sent
+ * then falling back to expiry.
  */
 export const selectBestOrder = (state: RootState) =>
   state.orders.orders.sort((a, b) => {
+    // If tokens transferred are the same
+    if (
+      a.signerAmount === b.signerAmount &&
+      a.senderAmount === b.senderAmount
+    ) {
+      return parseInt(b.expiry) - parseInt(a.expiry);
+    }
     if (a.signerAmount === b.signerAmount) {
       // Likely senderSide
       // Sort orders by amount of senderToken sent (ascending).


### PR DESCRIPTION
Closes #60 

- Changes `selectOrder` which previously selected the first order, to `selectBestOrder` which selects based on either receiving the most `signerToken` in the case of a `signerSideOrder` or sending the least `senderToken` in the case of a `senderSideOrder`

Have skipped the case where two orders are exactly the same in quantities as I feel this is unlikely to happen. 