### PR TITLE
Fixed bug; transactions accidentally persisted in localStorage throug…

### DIFF
--- a/src/features/metadata/metadataApi.ts
+++ b/src/features/metadata/metadataApi.ts
@@ -23,9 +23,11 @@ const tokensCache: {
   [chainId: number]: Promise<TokenInfo[]>;
 } = {};
 
-export const getActiveTokensLocalStorageKey: (chainId: number) => string = (
-  chainId
-) => `airswap/activeTokens/${chainId}`;
+export const getActiveTokensLocalStorageKey: (
+  account: string,
+  chainId: number
+) => string = (account, chainId) =>
+  `airswap/activeTokens/${account}/${chainId}`;
 
 export const getAllTokens = async (chainId: number) => {
   let tokens;
@@ -37,9 +39,12 @@ export const getAllTokens = async (chainId: number) => {
   return tokens;
 };
 
-export const getActiveTokensFromLocalStorage = (chainId: number) => {
+export const getActiveTokensFromLocalStorage = (
+  account: string,
+  chainId: number
+) => {
   const savedTokens = (
-    localStorage.getItem(getActiveTokensLocalStorageKey(chainId)) || ""
+    localStorage.getItem(getActiveTokensLocalStorageKey(account, chainId)) || ""
   )
     .split(",")
     .filter((address) => address.length);
@@ -48,15 +53,20 @@ export const getActiveTokensFromLocalStorage = (chainId: number) => {
   );
 };
 
-export const getSavedActiveTokensInfo = async (chainId: number) => {
+export const getSavedActiveTokensInfo = async (
+  account: string,
+  chainId: number
+) => {
   const tokens = await getAllTokens(chainId);
-  const activeTokens = getActiveTokensFromLocalStorage(chainId);
+  const activeTokens = getActiveTokensFromLocalStorage(account, chainId);
   const matchingTokens = tokens.filter((tokenInfo) =>
     activeTokens.includes(tokenInfo.address)
   );
   return uniqBy(matchingTokens, (token) => token.address);
 };
 
-export const getTransactionsLocalStorageKey: (chainId: number, walletAddress: string) => string = (
-  chainId, walletAddress
-) => `airswap/transactions/${chainId}/${walletAddress}`;
+export const getTransactionsLocalStorageKey: (
+  chainId: number,
+  walletAddress: string
+) => string = (chainId, walletAddress) =>
+  `airswap/transactions/${chainId}/${walletAddress}`;

--- a/src/features/metadata/metadataApi.ts
+++ b/src/features/metadata/metadataApi.ts
@@ -66,7 +66,7 @@ export const getSavedActiveTokensInfo = async (
 };
 
 export const getTransactionsLocalStorageKey: (
-  chainId: number,
-  walletAddress: string
-) => string = (chainId, walletAddress) =>
-  `airswap/transactions/${chainId}/${walletAddress}`;
+  walletAddress: string,
+  chainId: number
+) => string = (walletAddress, chainId) =>
+  `airswap/transactions/${walletAddress}/${chainId}`;

--- a/src/features/metadata/metadataSlice.ts
+++ b/src/features/metadata/metadataSlice.ts
@@ -11,7 +11,10 @@ import {
   setWalletConnected,
   setWalletDisconnected,
 } from "../wallet/walletSlice";
-import { getActiveTokensFromLocalStorage } from "./metadataApi";
+import {
+  defaultActiveTokens,
+  getActiveTokensFromLocalStorage,
+} from "./metadataApi";
 
 export interface MetadataState {
   tokens: {
@@ -82,8 +85,11 @@ export const metadataSlice = createSlice({
         // TODO: handle failure?
       })
       .addCase(setWalletConnected, (state, action) => {
-        const { chainId } = action.payload;
-        state.tokens.active = getActiveTokensFromLocalStorage(chainId);
+        const { chainId, address } = action.payload;
+        state.tokens.active =
+          getActiveTokensFromLocalStorage(address, chainId) ||
+          defaultActiveTokens[chainId] ||
+          [];
       })
       .addCase(setWalletDisconnected, (state) => {
         state.tokens.active = [];

--- a/src/features/metadata/metadataSubscriber.ts
+++ b/src/features/metadata/metadataSubscriber.ts
@@ -1,37 +1,70 @@
 import { store } from "../../app/store";
 import {
   getActiveTokensLocalStorageKey,
-  getTransactionsLocalStorageKey } from "./metadataApi";
-import { SubmittedTransaction } from '../transactions/transactionsSlice';
-
+  getTransactionsLocalStorageKey,
+} from "./metadataApi";
+import {
+  SubmittedTransaction,
+  TransactionsState,
+} from "../transactions/transactionsSlice";
 
 export const subscribeToSavedTokenChangesForLocalStoragePersisting = () => {
   const cache: {
     [chainId: number]: string[];
   } = {};
   const transactionCache: {
-    [chainId: number]: SubmittedTransaction[];
-  } = {}
+    [chainId: number]: {
+      [address: string]: SubmittedTransaction[];
+    };
+  } = {};
+
+  let currentTransaction: TransactionsState;
+
   store.subscribe(() => {
     const { wallet, metadata, transactions } = store.getState();
     if (!wallet.connected) return;
-    // persist all transactions to localStorage
-    const transactionCached = transactionCache[wallet.chainId!];
-    if (transactions.all.length && transactionCached !== transactions.all) {
-      localStorage.setItem(
-        getTransactionsLocalStorageKey(wallet.chainId!, wallet.address!),
-        JSON.stringify(transactions)
-      );
+
+    let previousTransaction = currentTransaction;
+    currentTransaction = transactions;
+
+    if (wallet && transactions) {
+      if (previousTransaction !== currentTransaction) {
+        // handles change in transactions and persists all transactions to localStorage
+        // TODO: don't save all transactions (e.g. max 10 transactions)
+        const txs: TransactionsState = JSON.parse(
+          localStorage.getItem(
+            getTransactionsLocalStorageKey(wallet.chainId!, wallet.address!)
+          )!
+        ) || { all: [] };
+
+        if (transactionCache[wallet.chainId!] === undefined) {
+          transactionCache[wallet.chainId!] = {};
+          transactionCache[wallet.chainId!][wallet.address!] = txs.all;
+        }
+        if (
+          transactions.all.length &&
+          transactionCache[wallet.chainId!][wallet.address!] !==
+            transactions.all
+        ) {
+          transactionCache[wallet.chainId!][wallet.address!] = transactions.all;
+          localStorage.setItem(
+            getTransactionsLocalStorageKey(wallet.chainId!, wallet.address!),
+            JSON.stringify(transactions)
+          );
+        }
+      }
     }
 
-    // active tokens have changed, persist to local storage.
-    const cached = cache[wallet.chainId!];
-    if (metadata.tokens.active.length && cached !== metadata.tokens.active) {
-      cache[wallet.chainId!] = metadata.tokens.active;
-      localStorage.setItem(
-        getActiveTokensLocalStorageKey(wallet.chainId!),
-        metadata.tokens.active.join(",")
-      );
+    if (wallet && metadata) {
+      // active tokens have changed, persist to local storage.
+      const cached = cache[wallet.chainId!];
+      if (metadata.tokens.active.length && cached !== metadata.tokens.active) {
+        cache[wallet.chainId!] = metadata.tokens.active;
+        localStorage.setItem(
+          getActiveTokensLocalStorageKey(wallet.chainId!),
+          metadata.tokens.active.join(",")
+        );
+      }
     }
   });
 };

--- a/src/features/metadata/metadataSubscriber.ts
+++ b/src/features/metadata/metadataSubscriber.ts
@@ -10,13 +10,13 @@ import {
 
 export const subscribeToSavedTokenChangesForLocalStoragePersisting = () => {
   const activeTokensCache: {
-    [chainId: number]: {
-      [address: string]: string[];
+    [address: string]: {
+      [chainId: number]: string[];
     };
   } = {};
   const transactionCache: {
-    [chainId: number]: {
-      [address: string]: SubmittedTransaction[];
+    [address: string]: {
+      [chainId: number]: SubmittedTransaction[];
     };
   } = {};
 
@@ -34,37 +34,37 @@ export const subscribeToSavedTokenChangesForLocalStoragePersisting = () => {
       // TODO: don't save all transactions (e.g. max 10 transactions)
       const txs: TransactionsState = JSON.parse(
         localStorage.getItem(
-          getTransactionsLocalStorageKey(wallet.chainId!, wallet.address!)
+          getTransactionsLocalStorageKey(wallet.address!, wallet.chainId!)
         )!
       ) || { all: [] };
 
-      if (transactionCache[wallet.chainId!] === undefined) {
-        transactionCache[wallet.chainId!] = {};
-        transactionCache[wallet.chainId!][wallet.address!] = txs.all;
+      if (transactionCache[wallet.address!] === undefined) {
+        transactionCache[wallet.address!] = {};
+        transactionCache[wallet.address!][wallet.chainId!] = txs.all;
       }
       if (
         transactions.all.length &&
-        transactionCache[wallet.chainId!][wallet.address!] !== transactions.all
+        transactionCache[wallet.address!][wallet.chainId!] !== transactions.all
       ) {
-        transactionCache[wallet.chainId!][wallet.address!] = transactions.all;
+        transactionCache[wallet.address!][wallet.chainId!] = transactions.all;
         localStorage.setItem(
-          getTransactionsLocalStorageKey(wallet.chainId!, wallet.address!),
+          getTransactionsLocalStorageKey(wallet.address!, wallet.chainId!),
           JSON.stringify(transactions)
         );
       }
     }
 
-    if (!activeTokensCache[wallet.chainId!]) {
-      activeTokensCache[wallet.chainId!] = {};
+    if (!activeTokensCache[wallet.address!]) {
+      activeTokensCache[wallet.address!] = {};
     }
     const cachedTokensForActiveWallet =
-      activeTokensCache[wallet.chainId!][wallet.address!];
+      activeTokensCache[wallet.address!][wallet.chainId!];
     if (
       metadata.tokens.active.length &&
       cachedTokensForActiveWallet !== metadata.tokens.active
     ) {
       // active tokens have changed, persist to local storage.
-      activeTokensCache[wallet.chainId!][wallet.address!] =
+      activeTokensCache[wallet.address!][wallet.chainId!] =
         metadata.tokens.active;
       localStorage.setItem(
         getActiveTokensLocalStorageKey(wallet.address!, wallet.chainId!),

--- a/src/features/transactions/Transactions.tsx
+++ b/src/features/transactions/Transactions.tsx
@@ -24,7 +24,7 @@ export function Transactions() {
     if (chainId && account && library) {
       const transactionsLocalStorage: TransactionsState = JSON.parse(
         localStorage.getItem(
-          getTransactionsLocalStorageKey(chainId!, account!)
+          getTransactionsLocalStorageKey(account!, chainId!)
         )!
       ) || { all: [] };
 


### PR DESCRIPTION
Oops, persisting transactions to localStorage had a minor bug!

To reproduce the bug:
1. make any transaction
2. switch chains (Rinkeby -> Mainnet)
3. transactions persist and localStorage for Mainnet is overridden by the one on Rinkeby
4. refreshing the page will still persist transactions that should've happened on Rinkeby on the Mainnet ui

To overcome the bug, I added a check to listen to transaction changes and updated the transactionCache structure. We might get a minor performance increase if we add a check to handle transaction changes, compared to the previous commit.