### PR TITLE
Issue 55: Add visual indicator if sender amount is greater than current balance

### DIFF
--- a/public/locales/en/orders.json
+++ b/public/locales/en/orders.json
@@ -7,5 +7,7 @@
   "send": "Send",
   "receive": "Receive",
   "amount": "Amount",
-  "chooseToken": "Choose token"
+  "chooseToken": "Choose token",
+  "enterAmount": "Enter an amount",
+  "insufficentBalance": "Insufficient {{symbol}} balance"
 }

--- a/src/components/TokenSelect/TokenSelect.tsx
+++ b/src/components/TokenSelect/TokenSelect.tsx
@@ -4,8 +4,6 @@ import { HiOutlineChevronRight } from "react-icons/hi";
 import { useTranslation } from "react-i18next";
 import LoadingSpinner from "../LoadingSpinner/LoadingSpinner";
 
-export type AmountStatus = "initial" | "sufficient" | "insufficient";
-
 type TokenSelectPropTypes = {
   withAmount: boolean;
   label: string;
@@ -13,15 +11,9 @@ type TokenSelectPropTypes = {
   amount?: string;
   token?: string;
   tokens: TokenInfo[];
-  amountStatus?: AmountStatus;
+  hasError?: boolean;
   onAmountChange?: React.FormEventHandler<HTMLInputElement>;
   onTokenChange?: React.FormEventHandler<HTMLSelectElement>;
-};
-
-const colorClasses: Record<AmountStatus, string> = {
-  initial: "dark:text-white",
-  sufficient: "dark:text-white",
-  insufficient: "dark:text-red-700 text-red-700",
 };
 
 const TokenSelect = ({
@@ -33,7 +25,7 @@ const TokenSelect = ({
   onAmountChange,
   token,
   onTokenChange,
-  amountStatus = "initial",
+  hasError = false,
 }: TokenSelectPropTypes) => {
   const { t } = useTranslation(["common", "orders"]);
 
@@ -54,7 +46,7 @@ const TokenSelect = ({
             className={classNames(
               "bg-transparent border-0 px-0 py-0",
               "placeholder-gray-500 text-sm",
-              colorClasses[amountStatus]
+              hasError ? "dark:text-red-700 text-red-700": "dark:text-white"
             )}
             value={amount}
             onChange={onAmountChange}

--- a/src/components/TokenSelect/TokenSelect.tsx
+++ b/src/components/TokenSelect/TokenSelect.tsx
@@ -4,6 +4,8 @@ import { HiOutlineChevronRight } from "react-icons/hi";
 import { useTranslation } from "react-i18next";
 import LoadingSpinner from "../LoadingSpinner/LoadingSpinner";
 
+export type AmountStatus = "initial" | "sufficient" | "insufficient";
+
 type TokenSelectPropTypes = {
   withAmount: boolean;
   label: string;
@@ -11,8 +13,15 @@ type TokenSelectPropTypes = {
   amount?: string;
   token?: string;
   tokens: TokenInfo[];
+  amountStatus?: AmountStatus;
   onAmountChange?: React.FormEventHandler<HTMLInputElement>;
   onTokenChange?: React.FormEventHandler<HTMLSelectElement>;
+};
+
+const colorClasses: Record<AmountStatus, string> = {
+  initial: "dark:text-white",
+  sufficient: "dark:text-white",
+  insufficient: "dark:text-red-700 text-red-700",
 };
 
 const TokenSelect = ({
@@ -24,6 +33,7 @@ const TokenSelect = ({
   onAmountChange,
   token,
   onTokenChange,
+  amountStatus = "initial",
 }: TokenSelectPropTypes) => {
   const { t } = useTranslation(["common", "orders"]);
 
@@ -44,7 +54,7 @@ const TokenSelect = ({
             className={classNames(
               "bg-transparent border-0 px-0 py-0",
               "placeholder-gray-500 text-sm",
-              "dark:text-white"
+              colorClasses[amountStatus]
             )}
             value={amount}
             onChange={onAmountChange}

--- a/src/features/orders/Orders.tsx
+++ b/src/features/orders/Orders.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { FormEvent, useState } from "react";
 import { toDecimalString } from "@airswap/utils";
 import { Web3Provider } from "@ethersproject/providers";
 import { useWeb3React } from "@web3-react/core";
@@ -18,19 +18,30 @@ import { selectActiveTokens } from "../metadata/metadataSlice";
 import { useTranslation } from "react-i18next";
 import { useMatomo } from "@datapunt/matomo-tracker-react";
 import Card from "../../components/Card/Card";
-import TokenSelect from "../../components/TokenSelect/TokenSelect";
+import TokenSelect, {
+  AmountStatus,
+} from "../../components/TokenSelect/TokenSelect";
 import Timer from "../../components/Timer/Timer";
 import Button from "../../components/Button/Button";
+import { toAtomicString } from "@airswap/utils";
+import { useEffect } from "react";
+import { selectBalances } from "../balances/balancesSlice";
+import { BigNumber } from "ethers";
+import { findTokenByAddress } from "@airswap/metadata";
+
+const floatRegExp = new RegExp("^[+-]?([0-9]+([.][0-9]*)?|[.][0-9]+)$");
 
 export function Orders() {
   const order = useAppSelector(selectBestOrder);
   const ordersStatus = useAppSelector(selectOrdersStatus);
   const transactions = useAppSelector(selectTransactions);
+  const balances = useAppSelector(selectBalances);
   const dispatch = useAppDispatch();
   const activeTokens = useAppSelector(selectActiveTokens);
   const [senderToken, setSenderToken] = useState<string>();
   const [signerToken, setSignerToken] = useState<string>();
-  const [senderAmount, setSenderAmount] = useState("0.01");
+  const [senderAmount, setSenderAmount] = useState<string>("0.0");
+  const [amountStatus, setAmountStatus] = useState<AmountStatus>("initial");
   const { chainId, account, library, active } = useWeb3React<Web3Provider>();
   const { t } = useTranslation(["orders", "common"]);
   const { trackEvent } = useMatomo();
@@ -39,6 +50,32 @@ export function Orders() {
   if (order) {
     signerAmount = toDecimalString(order.signerAmount, 6);
   }
+
+  useEffect(() => {
+    if (senderAmount && senderToken && balances) {
+      if (parseFloat(senderAmount) === 0) {
+        setAmountStatus("initial");
+        return;
+      }
+      const amount = BigNumber.from(toAtomicString(senderAmount!, 18));
+      const currentBalance = BigNumber.from(
+        balances.values[senderToken!] || toAtomicString("0", 18)
+      );
+      if (amount.lte(currentBalance)) {
+        setAmountStatus("sufficient"); // if senderAmount <= currentBalance, we have sufficient balance for transaction
+      } else {
+        setAmountStatus("insufficient"); // if senderAmount > currentBalance, we have insufficient balance for transaction
+      }
+    }
+  }, [senderAmount, senderToken, balances]);
+
+  // function to only allow numerical and dot values to be inputted
+  const handleTokenAmountChange = (e: FormEvent<HTMLInputElement>) => {
+    const value = e.currentTarget.value;
+    if (value === "" || floatRegExp.test(value)) {
+      setSenderAmount(value);
+    }
+  };
 
   const getTokenApprovalStatus = (tokenId: string | undefined) => {
     if (tokenId === undefined) return null;
@@ -61,11 +98,12 @@ export function Orders() {
         tokens={activeTokens}
         withAmount={true}
         amount={senderAmount}
-        onAmountChange={(e) => setSenderAmount(e.currentTarget.value)}
+        onAmountChange={(e) => handleTokenAmountChange(e)}
         className="mb-2"
         label={t("orders:send")}
         token={senderToken}
         onTokenChange={(e) => setSenderToken(e.currentTarget.value)}
+        amountStatus={amountStatus}
       />
       <TokenSelect
         tokens={activeTokens}
@@ -78,7 +116,12 @@ export function Orders() {
       <Button
         className="w-full mt-2"
         intent="primary"
-        disabled={!senderToken || !signerToken || !senderAmount}
+        disabled={
+          !senderToken ||
+          !signerToken ||
+          !senderAmount ||
+          amountStatus !== "sufficient"
+        }
         loading={ordersStatus === "requesting"}
         onClick={() => {
           dispatch(
@@ -94,7 +137,12 @@ export function Orders() {
           trackEvent({ category: "order", action: "request" });
         }}
       >
-        {t("orders:request")}
+        {amountStatus === "initial" && "Enter an amount"}
+        {amountStatus === "sufficient" && t("orders:request")}
+        {amountStatus === "insufficient" &&
+          `Insufficient ${
+            findTokenByAddress(senderToken!, activeTokens).symbol
+          } balance`}
       </Button>
       {signerAmount ? (
         <div>


### PR DESCRIPTION
New pr 👯‍♂️ 

Added feature to enable red text whenever senderAmount is greater than the current balance. 

Features:
1. Input text turns red if senderAmount is greater than the current balance.
2. Request button texts changes to have 3 options: "Enter an Amount" (initial), "Request" (sufficient), "Insufficient ___ balance" (insufficient)
3. Added `handleTokenAmountChange` function to handle non numeric and period values into input.
4. new AmountStatus type in `TokenSelect.tsx`

Some discussion points:
1. Do all tokens have 18 decimal denominations? I assumed they do, so calculate balance and current senderAmount based off of that.
2. Should a user still be able to request a quote if they don't have enough balance?
3. Is AmountStatus a good name for the status of the senderAmount? (I'm thinking we should change it to something better but idk what)

Please leave some feedback!