### PR TITLE
SwapWidget Wallet Connection

### DIFF
--- a/src/features/wallet/Wallet.tsx
+++ b/src/features/wallet/Wallet.tsx
@@ -28,7 +28,12 @@ import {
   loadLastAccount,
   saveLastAccount,
 } from "./walletAPI";
-import { setWalletConnected, setWalletDisconnected } from "./walletSlice";
+import {
+  setWalletConnected,
+  setWalletDisconnected,
+  selectWallet,
+} from "./walletSlice";
+import SUPPORTED_WALLET_PROVIDERS from "../../constants/supportedWalletProviders";
 
 export const Wallet = () => {
   const {
@@ -44,6 +49,7 @@ export const Wallet = () => {
   const dispatch = useAppDispatch();
   const activeTokens = useAppSelector(selectActiveTokens);
   const balances = useAppSelector(selectBalances);
+  const { providerName } = useAppSelector(selectWallet);
 
   // Analytics
   const { trackPageView } = useMatomo();
@@ -69,6 +75,18 @@ export const Wallet = () => {
       activate(connector).finally(() => setIsActivating(false));
     }
   }, [activate, trackPageView]);
+
+  // Side effects for connecting a wallet from SwapWidget
+
+  useEffect(() => {
+    if (providerName) {
+      const provider = SUPPORTED_WALLET_PROVIDERS.find(
+        (provider) => provider.name === providerName
+      );
+      setProvider(provider);
+      setConnector(provider!.getConnector());
+    }
+  }, [providerName]);
 
   // Trigger request for balances and allowances once account is connected
   useEffect(() => {

--- a/src/features/wallet/walletSlice.ts
+++ b/src/features/wallet/walletSlice.ts
@@ -5,12 +5,14 @@ export interface WalletState {
   connected: boolean;
   address: string | null;
   chainId: number | null;
+  providerName: string | null;
 }
 
 const initialState: WalletState = {
   connected: false,
   address: null,
   chainId: null,
+  providerName: null,
 };
 
 const walletSlice = createSlice({
@@ -26,6 +28,9 @@ const walletSlice = createSlice({
       state.chainId = action.payload.chainId;
     },
     setWalletDisconnected: () => initialState,
+    setActiveProvider: (state, action: PayloadAction<string>) => {
+      state.providerName = action.payload;
+    },
   },
 });
 
@@ -34,6 +39,7 @@ export const selectWallet = (state: RootState) => state.wallet;
 export const {
   setWalletConnected,
   setWalletDisconnected,
+  setActiveProvider,
 } = walletSlice.actions;
 
 export default walletSlice.reducer;


### PR DESCRIPTION
Per an earlier conversation with @gpxl-dev, I made the following changes to wire up the connect wallet button in `SwapWidget`:

1. Updated redux state to allow setting a `providerName`
2. Added local state to toggle between loading modes for the connect wallet button
3. Added a `useEffect` inside `Wallet.tsx` to set `provider` and `connector` so that the other `useEffect` that fetches balances etc. is triggered.
4. Updated `onProviderSelected` logic for the `WalletList` component

Points for discussion:

1. It was discussed adding a `connecting` state to the wallet redux state in the event we have multiple connect wallet buttons, I had started to add that in but stopped because 
    a. I wasn't sure if we would even need local loading state anymore (in favor of the redux state).
    b. I supposed we should probably hammer this out with the designers before making any additional changes to redux.