### PR TITLE
Restrict tokens to those in registry

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "@airswap/balances": "^1.1.2",
     "@airswap/constants": "^0.4.0",
     "@airswap/metadata": "^0.3.2",
-    "@airswap/protocols": "^0.5.7",
+    "@airswap/protocols": "0.5.9",
     "@airswap/types": "^3.5.17",
     "@craco/craco": "^6.2.0",
     "@datapunt/matomo-tracker-react": "^0.4.0",

--- a/public/locales/en/balances.json
+++ b/public/locales/en/balances.json
@@ -1,6 +1,7 @@
 {
   "tokenBalances": "Token balances",
   "addToTokenSet": "Import",
+  "unsupportedToken": "Not yet supported",
   "symbol": "Symbol",
   "balance": "Balance",
   "allowance": "Allowance"

--- a/src/app/store.ts
+++ b/src/app/store.ts
@@ -7,6 +7,7 @@ import {
 import metadataReducer from "../features/metadata/metadataSlice";
 import { subscribeToSavedTokenChangesForLocalStoragePersisting } from "../features/metadata/metadataSubscriber";
 import ordersReducer from "../features/orders/ordersSlice";
+import registryReducer from "../features/registry/registrySlice";
 import transactionsReducer from "../features/transactions/transactionsSlice";
 import userSettingsReducer from "../features/userSettings/userSettingsSlice";
 import walletReducer from "../features/wallet/walletSlice";
@@ -19,6 +20,7 @@ export const store = configureStore({
     metadata: metadataReducer,
     orders: ordersReducer,
     wallet: walletReducer,
+    registry: registryReducer,
     userSettings: userSettingsReducer,
   },
 });

--- a/src/components/SwapWidget/SwapWidget.tsx
+++ b/src/components/SwapWidget/SwapWidget.tsx
@@ -39,6 +39,7 @@ import {
   selectOrdersStatus,
   clear,
 } from "../../features/orders/ordersSlice";
+import { selectAllSupportedTokens } from "../../features/registry/registrySlice";
 import {
   SubmittedApproval,
   selectTransactions,
@@ -82,6 +83,7 @@ const SwapWidget = () => {
   const ordersStatus = useAppSelector(selectOrdersStatus);
   const activeTokens = useAppSelector(selectActiveTokens);
   const allTokens = useAppSelector(selectAllTokenInfo);
+  const supportedTokens = useAppSelector(selectAllSupportedTokens);
   const { t } = useTranslation(["orders", "common", "wallet", "balances"]);
   const {
     chainId,
@@ -439,6 +441,7 @@ const SwapWidget = () => {
           balances={balances}
           allTokens={allTokens}
           activeTokens={activeTokens}
+          supportedTokenAddresses={supportedTokens}
           addActiveToken={handleAddActiveToken}
           removeActiveToken={handleRemoveActiveToken}
           onClose={() => setShowTokenSelection(false)}

--- a/src/components/TokenSelection/TokenSelection.stories.tsx
+++ b/src/components/TokenSelection/TokenSelection.stories.tsx
@@ -86,6 +86,8 @@ Default.args = {
   },
   allTokens: allTokens,
   activeTokens: activeTokens,
+  // TODO:
+  supportedTokenAddresses: [],
   addActiveToken: () => void 1,
   removeActiveToken: () => void 1,
   chainId: 1,
@@ -111,6 +113,8 @@ TestNet.args = {
   },
   allTokens: allTokens,
   activeTokens: activeTokens,
+  // TODO:
+  supportedTokenAddresses: [],
   addActiveToken: () => void 1,
   removeActiveToken: () => void 1,
   chainId: 4,

--- a/src/components/TokenSelection/TokenSelection.tsx
+++ b/src/components/TokenSelection/TokenSelection.tsx
@@ -90,6 +90,7 @@ const TokenSelection = ({
   balances,
   allTokens,
   activeTokens = [],
+  supportedTokenAddresses,
   addActiveToken,
   removeActiveToken,
   chainId,
@@ -195,6 +196,7 @@ const TokenSelection = ({
             tokenQuery={tokenQuery}
             activeTokens={activeTokens}
             allTokens={allTokens}
+            supportedTokenAddresses={supportedTokenAddresses}
             onTokenClick={(tokenAddress) => {
               addActiveToken(tokenAddress);
               setTokenQuery("");

--- a/src/components/TokenSelection/TokenSelection.tsx
+++ b/src/components/TokenSelection/TokenSelection.tsx
@@ -63,6 +63,10 @@ export type TokenSelectionProps = {
    */
   activeTokens: TokenInfo[];
   /**
+   * Supported tokens according to registry
+   */
+  supportedTokenAddresses: string[];
+  /**
    * function to handle adding active tokens (dispatches addActiveToken).
    */
   addActiveToken: (val: string) => void;

--- a/src/components/TokenSelection/subcomponents/InactiveTokensList/InactiveTokensList.tsx
+++ b/src/components/TokenSelection/subcomponents/InactiveTokensList/InactiveTokensList.tsx
@@ -17,12 +17,14 @@ type InactiveTokensListProps = {
   tokenQuery: string;
   allTokens: TokenInfo[];
   activeTokens: TokenInfo[];
+  supportedTokenAddresses: string[];
   onTokenClick: (tokenAddress: string) => void;
 };
 
 const InactiveTokensList = ({
   tokenQuery,
   allTokens,
+  supportedTokenAddresses,
   activeTokens,
   onTokenClick,
 }: InactiveTokensListProps) => {
@@ -57,6 +59,10 @@ const InactiveTokensList = ({
         {inactiveTokens.map((token) => (
           <TokenImportButton
             token={token}
+            isUnsupported={
+              supportedTokenAddresses.length !== 0 &&
+              !supportedTokenAddresses.includes(token.address)
+            }
             onClick={() => onTokenClick(token.address)}
             key={`${token.address}`}
           />

--- a/src/components/TokenSelection/subcomponents/TokenImportButton/TokenImportButton.styles.tsx
+++ b/src/components/TokenSelection/subcomponents/TokenImportButton/TokenImportButton.styles.tsx
@@ -1,12 +1,14 @@
 import styled from "styled-components/macro";
 
+import { Metadata } from "../../../Typography/Typography";
+
 export const Container = styled.div`
   border: 1px solid ${(props) => props.theme.colors.borderGrey};
   padding: 1rem;
   display: grid;
   grid-auto-flow: column;
   cursor: pointer;
-  grid-template-columns: auto minmax(auto, 1fr) auto minmax(0, 72px);
+  grid-template-columns: auto minmax(auto, 1fr) 6.25rem;
   grid-gap: 1rem;
   align-items: center;
 
@@ -52,14 +54,19 @@ export const TokenName = styled.h3`
 
 export const Span = styled.span``;
 
+export const UnsupportedTokenText = styled(Metadata)`
+  text-align: center;
+  justify-self: center;
+`;
+
 export const ImportButton = styled.button`
   border: 1px solid ${(props) => props.theme.colors.borderGrey};
   font-size: 0.8rem;
   font-weight: bold;
   padding: 0.5rem 1.5rem;
-  justify-self: end;
+  justify-self: center;
 
-  &:hover {
+  &:hover:not(:disabled) {
     background: ${(props) => props.theme.colors.white};
     color: ${(props) => props.theme.colors.black};
     transition: 0.25s ease-in-out;

--- a/src/components/TokenSelection/subcomponents/TokenImportButton/TokenImportButton.tsx
+++ b/src/components/TokenSelection/subcomponents/TokenImportButton/TokenImportButton.tsx
@@ -11,6 +11,7 @@ import {
   TokenName,
   Span,
   ImportButton,
+  UnsupportedTokenText,
 } from "./TokenImportButton.styles";
 
 export type TokenImportRowProps = {
@@ -19,12 +20,20 @@ export type TokenImportRowProps = {
    */
   token: TokenInfo;
   /**
+   * True if the token isn't currently supported by makers.
+   */
+  isUnsupported: boolean;
+  /**
    * onClick event, either setSignerToken or setSenderToken
    */
   onClick: (val: string) => void;
 };
 
-const TokenImportButton = ({ token, onClick }: TokenImportRowProps) => {
+const TokenImportButton = ({
+  token,
+  onClick,
+  isUnsupported,
+}: TokenImportRowProps) => {
   const { t } = useTranslation(["balances", "common"]);
 
   return (
@@ -40,10 +49,15 @@ const TokenImportButton = ({ token, onClick }: TokenImportRowProps) => {
         <Symbol>{token.symbol}</Symbol>
         <TokenName>{token.name}</TokenName>
       </TextContainer>
-      <Span></Span>
-      <ImportButton onClick={() => onClick(token.address)}>
-        {t("balances:addToTokenSet")}
-      </ImportButton>
+      {isUnsupported ? (
+        <UnsupportedTokenText>
+          {t("balances:unsupportedToken")}
+        </UnsupportedTokenText>
+      ) : (
+        <ImportButton onClick={() => onClick(token.address)}>
+          {t("balances:addToTokenSet")}
+        </ImportButton>
+      )}
     </Container>
   );
 };

--- a/src/components/WalletButton/subcomponents/TransactionLink/TransactionLink.tsx
+++ b/src/components/WalletButton/subcomponents/TransactionLink/TransactionLink.tsx
@@ -13,7 +13,7 @@ const TransactionLink = ({ chainId, hash }: TransactionLinkProps) => {
     <Link
       target="_blank"
       rel="noreferrer"
-      href={`${getEtherscanURL(`${chainId}`, hash)}`}
+      href={`${getEtherscanURL(chainId, hash)}`}
     >
       <Icon iconSize={0.75} name="transaction-link" />
     </Link>

--- a/src/features/registry/registryAPI.tsx
+++ b/src/features/registry/registryAPI.tsx
@@ -1,0 +1,72 @@
+import * as RegistryContract from "@airswap/registry/build/contracts/Registry.sol/Registry.json";
+import registryDeploys from "@airswap/registry/deploys.js";
+
+import { providers, utils, Contract, Event } from "ethers";
+import uniqBy from "lodash.uniqby";
+
+const RegistryInterface = new utils.Interface(
+  JSON.stringify(RegistryContract.abi)
+);
+
+async function getAllSupportedTokens(
+  chainId: number,
+  provider: providers.Provider
+) {
+  const registryContract = new Contract(
+    registryDeploys[chainId],
+    RegistryInterface,
+    provider
+  );
+
+  const addTokensEventFilter = registryContract.filters.AddTokens();
+  const removeTokensEventFilter = registryContract.filters.RemoveTokens();
+
+  // Fetch all AddTokens and RemoveTokens events from the registry
+  const [addEvents, removeEvents] = await Promise.all([
+    registryContract.queryFilter(addTokensEventFilter),
+    registryContract.queryFilter(removeTokensEventFilter),
+  ]);
+
+  // Order matters here, so order AddTokens and RemoveTokens chronologically
+  const sortedEvents: Event[] = [...addEvents, ...removeEvents]
+    .filter((log) => !log.removed)
+    .sort((a, b) => {
+      // Sort by oldest first. If they're not in the same block, sort based
+      // on blocknumber
+      if (a.blockNumber !== b.blockNumber) return a.blockNumber - b.blockNumber;
+      // if in the same block, sort by the index of the log in the block
+      return a.logIndex - b.logIndex;
+    });
+
+  // Hold a list of tokens for each staker.
+  const stakerTokens: Record<string, string[]> = {};
+
+  sortedEvents.forEach((log) => {
+    // TODO: On rinkeby, args are null...
+    if (!log.args) return;
+    // @ts-ignore (args are not typed)
+    const [staker, tokens] = log.args as string[];
+    if (log.event === "AddTokens") {
+      // Adding tokens
+      stakerTokens[staker] = (stakerTokens[staker] || []).concat(tokens);
+    } else {
+      // Removing tokens
+      stakerTokens[staker] = (stakerTokens[staker] || []).filter(
+        (token) => !tokens.includes(token)
+      );
+    }
+  });
+
+  // Combine token lists from all makers and flatten them.
+  const allSupportedTokens = uniqBy(
+    Object.values(stakerTokens)
+      .flat()
+      .map((addr) => addr.toLowerCase()),
+    (i) => i
+  );
+  console.log(allSupportedTokens);
+
+  return allSupportedTokens;
+}
+
+export { getAllSupportedTokens };

--- a/src/features/registry/registryAPI.tsx
+++ b/src/features/registry/registryAPI.tsx
@@ -40,14 +40,17 @@ async function getStakerTokens(chainId: number, provider: providers.Provider) {
   sortedEvents.forEach((log) => {
     if (!log.args) return;
     // @ts-ignore (args are not typed)
-    const [staker, tokens] = log.args as string[];
+    const [staker, tokens] = log.args as [string, string[]];
+    const lowerCasedTokens = tokens.map((t) => t.toLowerCase());
     if (log.event === "AddTokens") {
       // Adding tokens
-      stakerTokens[staker] = (stakerTokens[staker] || []).concat(tokens);
+      stakerTokens[staker] = (stakerTokens[staker] || []).concat(
+        lowerCasedTokens
+      );
     } else {
       // Removing tokens
       stakerTokens[staker] = (stakerTokens[staker] || []).filter(
-        (token) => !tokens.includes(token)
+        (token) => !lowerCasedTokens.includes(token)
       );
     }
   });

--- a/src/features/registry/registryAPI.tsx
+++ b/src/features/registry/registryAPI.tsx
@@ -2,16 +2,12 @@ import * as RegistryContract from "@airswap/registry/build/contracts/Registry.so
 import registryDeploys from "@airswap/registry/deploys.js";
 
 import { providers, utils, Contract, Event } from "ethers";
-import uniqBy from "lodash.uniqby";
 
 const RegistryInterface = new utils.Interface(
   JSON.stringify(RegistryContract.abi)
 );
 
-async function getAllSupportedTokens(
-  chainId: number,
-  provider: providers.Provider
-) {
+async function getStakerTokens(chainId: number, provider: providers.Provider) {
   const registryContract = new Contract(
     registryDeploys[chainId],
     RegistryInterface,
@@ -57,16 +53,7 @@ async function getAllSupportedTokens(
     }
   });
 
-  // Combine token lists from all makers and flatten them.
-  const allSupportedTokens = uniqBy(
-    Object.values(stakerTokens)
-      .flat()
-      .map((addr) => addr.toLowerCase()),
-    (i) => i
-  );
-  console.log(allSupportedTokens);
-
-  return allSupportedTokens;
+  return stakerTokens;
 }
 
-export { getAllSupportedTokens };
+export { getStakerTokens };

--- a/src/features/registry/registryAPI.tsx
+++ b/src/features/registry/registryAPI.tsx
@@ -38,7 +38,6 @@ async function getStakerTokens(chainId: number, provider: providers.Provider) {
   const stakerTokens: Record<string, string[]> = {};
 
   sortedEvents.forEach((log) => {
-    // TODO: On rinkeby, args are null...
     if (!log.args) return;
     // @ts-ignore (args are not typed)
     const [staker, tokens] = log.args as string[];

--- a/src/features/registry/registryDeploys.d.ts
+++ b/src/features/registry/registryDeploys.d.ts
@@ -1,0 +1,4 @@
+declare module "@airswap/registry/deploys.js" {
+  const deploys: { [chainId: number]: string };
+  export default deploys;
+}

--- a/src/features/registry/registrySlice.ts
+++ b/src/features/registry/registrySlice.ts
@@ -1,0 +1,86 @@
+import { createAsyncThunk, createSlice, PayloadAction } from "@reduxjs/toolkit";
+
+import { providers } from "ethers";
+import uniqBy from "lodash.uniqby";
+
+import { AppDispatch, RootState } from "../../app/store";
+import { getStakerTokens } from "./registryApi";
+
+export interface RegistryState {
+  stakerTokens: Record<string, string[]>;
+  allSupportedTokens: string[];
+  status: "idle" | "fetching" | "failed";
+}
+
+const initialState: RegistryState = {
+  stakerTokens: {},
+  allSupportedTokens: [],
+  status: "idle",
+};
+
+export const fetchSupportedTokens = createAsyncThunk<
+  { allSupportedTokens: string[]; stakerTokens: Record<string, string[]> },
+  {
+    provider: providers.Provider;
+  },
+  {
+    // Optional fields for defining thunkApi field types
+    dispatch: AppDispatch;
+    state: RootState;
+  }
+>("registry/fetchSupportedTokens", async ({ provider }, { getState }) => {
+  const stakerTokens = await getStakerTokens(
+    getState().wallet.chainId!,
+    provider
+  );
+  // Combine token lists from all makers and flatten them.
+  const allSupportedTokens = uniqBy(
+    Object.values(stakerTokens)
+      .flat()
+      .map((addr) => addr.toLowerCase()),
+    (i) => i
+  );
+  return { stakerTokens, allSupportedTokens };
+});
+
+export const registrySlice = createSlice({
+  name: "registry",
+  initialState,
+  reducers: {
+    setStakerTokens: (
+      state,
+      action: PayloadAction<Record<string, string[]>>
+    ) => {
+      state.stakerTokens = { ...action.payload };
+    },
+    setAllSupportedTokens: (state, action: PayloadAction<string[]>) => {
+      state.allSupportedTokens = [...action.payload];
+    },
+    reset: () => {
+      return { ...initialState };
+    },
+  },
+  extraReducers: (builder) => {
+    builder
+      .addCase(fetchSupportedTokens.pending, (state) => {
+        state.status = "fetching";
+      })
+      .addCase(fetchSupportedTokens.fulfilled, (state, action) => {
+        state.status = "idle";
+        state.allSupportedTokens = [...action.payload.allSupportedTokens];
+        state.stakerTokens = { ...action.payload.stakerTokens };
+      })
+      .addCase(fetchSupportedTokens.rejected, (state) => {
+        state.status = "failed";
+      });
+  },
+});
+
+export const {
+  setStakerTokens,
+  setAllSupportedTokens,
+  reset,
+} = registrySlice.actions;
+export const selectAllSupportedTokens = (state: RootState) =>
+  state.registry.allSupportedTokens;
+export default registrySlice.reducer;

--- a/src/features/registry/registrySlice.ts
+++ b/src/features/registry/registrySlice.ts
@@ -35,9 +35,7 @@ export const fetchSupportedTokens = createAsyncThunk<
   );
   // Combine token lists from all makers and flatten them.
   const allSupportedTokens = uniqBy(
-    Object.values(stakerTokens)
-      .flat()
-      .map((addr) => addr.toLowerCase()),
+    Object.values(stakerTokens).flat(),
     (i) => i
   );
   return { stakerTokens, allSupportedTokens };

--- a/src/features/transactions/Transactions.tsx
+++ b/src/features/transactions/Transactions.tsx
@@ -120,7 +120,7 @@ export function Transactions() {
           <a
             target="_blank"
             rel="noreferrer"
-            href={`${getEtherscanURL(`${chainId}`, submittedOrder.hash!)}`}
+            href={`${getEtherscanURL(chainId, submittedOrder.hash!)}`}
           >
             {submittedOrder.hash}
           </a>

--- a/src/features/wallet/Wallet.tsx
+++ b/src/features/wallet/Wallet.tsx
@@ -30,7 +30,7 @@ import {
   selectActiveTokens,
   selectAllTokenInfo,
 } from "../metadata/metadataSlice";
-import { getAllSupportedTokens } from "../registry/registryAPI";
+import { fetchSupportedTokens } from "../registry/registrySlice";
 import {
   revertTransaction,
   mineTransaction,
@@ -129,8 +129,11 @@ export const Wallet: FC<WalletProps> = ({ className = "" }) => {
           provider: library,
         })
       );
-
-      getAllSupportedTokens(chainId, library);
+      dispatch(
+        fetchSupportedTokens({
+          provider: library,
+        })
+      );
     } else {
       dispatch(setWalletDisconnected());
     }

--- a/src/features/wallet/Wallet.tsx
+++ b/src/features/wallet/Wallet.tsx
@@ -30,6 +30,7 @@ import {
   selectActiveTokens,
   selectAllTokenInfo,
 } from "../metadata/metadataSlice";
+import { getAllSupportedTokens } from "../registry/registryAPI";
 import {
   revertTransaction,
   mineTransaction,
@@ -128,6 +129,8 @@ export const Wallet: FC<WalletProps> = ({ className = "" }) => {
           provider: library,
         })
       );
+
+      getAllSupportedTokens(chainId, library);
     } else {
       dispatch(setWalletDisconnected());
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9,11 +9,6 @@
   dependencies:
     openzeppelin-solidity "2.4"
 
-"@airswap/constants@0.3.10":
-  version "0.3.10"
-  resolved "https://registry.yarnpkg.com/@airswap/constants/-/constants-0.3.10.tgz"
-  integrity sha512-74kT4lncU++lyXDUJC6j1V8uasMshyhRDhiSKnV/88Ll6S0d2MyvjARaKkCfp8JqFnMbcbWl5zUyzMmSoimuIA==
-
 "@airswap/constants@0.4.0", "@airswap/constants@^0.4.0":
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/@airswap/constants/-/constants-0.4.0.tgz"
@@ -57,30 +52,30 @@
     ethereumjs-abi "^0.6.8"
     ethers "^5.0.25"
 
-"@airswap/protocols@^0.5.7":
-  version "0.5.7"
-  resolved "https://registry.yarnpkg.com/@airswap/protocols/-/protocols-0.5.7.tgz#6f79f178f51d6c96b8dcc26b46e68162f6cfae98"
-  integrity sha512-u24a8YdjgZhfYtDwNojncoFB0KSxS1Zzps6XOE20AE/TLNmmc5gIcCCAWHS4VDTWqpOgG/B4JxWzwl+CMSTzMw==
+"@airswap/protocols@0.5.9":
+  version "0.5.9"
+  resolved "https://registry.yarnpkg.com/@airswap/protocols/-/protocols-0.5.9.tgz#bbe7c8cd6bf18473f9fea85ce7a422f68a116f83"
+  integrity sha512-iJsn9tCb90iN8rvkbWYreMtGFjkZTz/ue3f4u1BR+MwibyzJ/tDeKSP3wHNwKzCYMaaUfi+42m0kYSjKKyim+A==
   dependencies:
     "@airswap/constants" "0.4.0"
     "@airswap/delegate" "2.6.10"
     "@airswap/indexer" "3.6.11"
     "@airswap/light" "2.2.2"
-    "@airswap/registry" "4.6.1"
+    "@airswap/registry" "4.8.1"
     "@airswap/swap" "5.4.9"
     "@airswap/tokens" "0.1.4"
     "@airswap/types" "3.5.17"
-    "@airswap/utils" "0.4.4"
+    "@airswap/utils" "0.4.5"
     "@airswap/validator" "1.2.7"
     bignumber.js "^9.0.0"
     browser-or-node "^1.3.0"
     ethers "^5.0.25"
     jayson "^3.2.0"
 
-"@airswap/registry@4.6.1":
-  version "4.6.1"
-  resolved "https://registry.yarnpkg.com/@airswap/registry/-/registry-4.6.1.tgz#e1a2805106a132c830d83224cc17ec952f0c8143"
-  integrity sha512-+uW6p5ry7dLZoPhs3CD+kVBelw+IQE6JTT03JmFLSa3EVh+ICh9owgFYtDBNbjMploAomO0BfP2j0ycIrt+JtA==
+"@airswap/registry@4.8.1":
+  version "4.8.1"
+  resolved "https://registry.yarnpkg.com/@airswap/registry/-/registry-4.8.1.tgz#aa2aee29d50382dbf0b6473f96c47102c3640baa"
+  integrity sha512-+oQyca5seNtDbcOvBcKAcVbInf3b836E8xBrzUbuh7cCfkayfq0jqi+yBABSWmdYrgKRTL3ZG2mJFbDg1NpCgg==
 
 "@airswap/swap@5.4.9":
   version "5.4.9"
@@ -119,13 +114,13 @@
   dependencies:
     openzeppelin-solidity "2.4"
 
-"@airswap/utils@0.4.4":
-  version "0.4.4"
-  resolved "https://registry.yarnpkg.com/@airswap/utils/-/utils-0.4.4.tgz"
-  integrity sha512-ZXIsbUEJ5SaUEwLTGEqCUi0+thTXsmb+/keCnZ64Wzboa42On1q2v+E9xcITin19lJH1ZtNJHdUL1XBUY35qvQ==
+"@airswap/utils@0.4.5":
+  version "0.4.5"
+  resolved "https://registry.yarnpkg.com/@airswap/utils/-/utils-0.4.5.tgz#ce1cf86a335abccbcd515abce20ec09a07642da1"
+  integrity sha512-M4nukvKUvB5qAbNFOIUv0hJfWD//y25R6mYeqHB2MD3D1yZpKyGXEudNxrrGaJytx2iGL1uqCpGZU6pKSFLV+w==
   dependencies:
-    "@airswap/constants" "0.3.10"
-    "@airswap/types" "3.5.16"
+    "@airswap/constants" "0.4.0"
+    "@airswap/types" "3.5.17"
     "@types/ethereumjs-util" "^6.1.0"
     eth-sig-util "^3.0.0"
     ethereumjs-util "^6.2.0"


### PR DESCRIPTION
- Adds a `registry` slice to state which contains a list of the tokens supported by each staker (maker), as well as a list of all tokens supported across all makers.
- Updates the token selection screen to prevent importing unsupported tokens to a user's active tokens list
- Upgrades @airswap/protocols

This branch probably has a non-ideal UX, but preventing active token import is the fastest & most feasible way to implement pre-alpha.

Screenshot:
![image](https://user-images.githubusercontent.com/82473383/130047752-a0bd60bc-9e12-4325-bb57-9a24160db493.png)


Closes #126 