### PR TITLE
Don't show submitted screen if signature rejected

### DIFF
--- a/src/components/SwapWidget/SwapWidget.tsx
+++ b/src/components/SwapWidget/SwapWidget.tsx
@@ -202,8 +202,17 @@ const SwapWidget = () => {
             disabled={isNaN(parseFloat(signerAmount))}
             loading={ordersStatus === "taking"}
             onClick={async () => {
-              await dispatch(take({ order, library }));
-              setShowOrderSubmitted(true);
+              try {
+                const result = await dispatch(take({ order, library }));
+                await unwrapResult(result);
+                setShowOrderSubmitted(true);
+              } catch (e) {
+                if (e.code && e.code === 4001) {
+                  // 4001 is metamask user declining transaction sig, do nothing
+                } else {
+                  // FIXME: notify user - toast?
+                }
+              }
             }}
           >
             {t("orders:take")}

--- a/src/features/orders/ordersSlice.ts
+++ b/src/features/orders/ordersSlice.ts
@@ -82,8 +82,8 @@ export const approve = createAsyncThunk(
         });
       }
     } catch (e) {
-      console.error(e);
       dispatch(declineTransaction(e.message));
+      throw e;
     }
   }
 );
@@ -113,8 +113,8 @@ export const take = createAsyncThunk(
         });
       }
     } catch (e) {
-      console.error(e);
       dispatch(declineTransaction(e.message));
+      throw e;
     }
   }
 );


### PR DESCRIPTION
Previously rejecting a metamask signature request would essentially be ignored and incorrectly show the transaction submitted screen.

Note for anyone reading this who is new to redux toolkit - I had wrongly assumed that `await dispatch(someThunkGeneratingAction)` would throw if the thunk rejected. It doesn't - you need to use `unwrapResult`, like this:

```javascript
try {
  const result = await dispatch(someThunkGeneratingAction)
  await unwrapResult(result);
  // do success specific stuff.
} catch (e) {
  // you would never get here if you didn't await the unwrap.
}
```