### PR TITLE
Fix #139 (stuck approvals)

### DIFF
--- a/src/features/transactions/transactionsSlice.ts
+++ b/src/features/transactions/transactionsSlice.ts
@@ -48,7 +48,7 @@ function updateTransaction(
   }
 }
 
-export const ordersSlice = createSlice({
+export const transactionsSlice = createSlice({
   name: "transactions",
   initialState,
   reducers: {
@@ -80,6 +80,10 @@ export const ordersSlice = createSlice({
   },
 });
 
-export const { clear, setTransactions } = ordersSlice.actions;
+export const { clear, setTransactions } = transactionsSlice.actions;
 export const selectTransactions = (state: RootState) => state.transactions.all;
-export default ordersSlice.reducer;
+export const selectPendingApprovals = (state: RootState) =>
+  state.transactions.all.filter(
+    (tx) => tx.status === "processing" && tx.type === "Approval"
+  ) as SubmittedApproval[];
+export default transactionsSlice.reducer;


### PR DESCRIPTION
There were two parts to the reported issue:

1. The approval button didn't enter the loading state
2. Even after the transaction mined, allowance wasn't updated, and the app didn't proceed to a "ready to take" state.

### Approval button not showing as loading

This was hard to reproduce, but I believe it was down to the fact that the logic to check if there  was a pending approval was iterating through the list of all transactions looking for an approval TX for the token, and potentially not considering that there might be more than one (e.g. if token has been approved once and subsequently revoked). I updated this to simply check all pending approval transactions to see if any of them are for the sender token.

### Allowance not updating

I only managed to reproduce this once (even when I could reproduce the previous bug). I am not sure why this is, but am wondering whether perhaps this is to do with whatever polling or socket connection listens to contract events. Without being able to reliably reproduce, I decided the best course of action was to update the allowance of the token directly after the transaction is successfully mined (instead of waiting for the event that would do it). Note that the event does normally come in as well, which results in two allowance update actions, but the second one doesn't cause any changes to the state. I still think it is beneficial to listen to contract events to cover the case where allowance is updated externally.

Fixes #139 

Bonus fixes:

- renamed a badly named reducer
- Added an "approving" state. 