### PR TITLE
Fix #156

### DIFF
--- a/src/components/SwapWidget/SwapWidget.tsx
+++ b/src/components/SwapWidget/SwapWidget.tsx
@@ -294,7 +294,9 @@ const SwapWidget = () => {
           }}
         >
           {!insufficientBalance
-            ? !senderAmount || parseFloat(senderAmount) === 0
+            ? !senderAmount ||
+              parseFloat(senderAmount) === 0 ||
+              senderAmount === "."
               ? t("orders:enterAmount")
               : decimalsFound
               ? t("orders:continue")
@@ -321,7 +323,7 @@ const SwapWidget = () => {
   let insufficientBalance: boolean = false;
   let decimalsFound: boolean = true;
   if (senderAmount && senderToken && Object.keys(balances.values).length) {
-    if (parseFloat(senderAmount) === 0) {
+    if (parseFloat(senderAmount) === 0 || senderAmount === ".") {
       insufficientBalance = false;
     } else {
       const senderDecimals = getTokenDecimals(senderToken);


### PR DESCRIPTION
Fixes #156

Token select input regex allows entering `.`, which isn't a number and was causing `ethers.utils.parseUnits` to throw an error. 

This is the only non number that the regex will allow, so I've just added a couple of explicit checks for it in the SwapWidget logic.