### PR TITLE
Use on chain data if tokenLists are missing tokens

### DIFF
--- a/src/features/metadata/metadataApi.ts
+++ b/src/features/metadata/metadataApi.ts
@@ -1,6 +1,7 @@
-import { fetchTokens } from "@airswap/metadata";
+import { fetchTokens, scrapeToken } from "@airswap/metadata";
 import { TokenInfo } from "@uniswap/token-lists";
 
+import { providers } from "ethers";
 import uniqBy from "lodash.uniqby";
 
 const tokensCache: {
@@ -13,6 +14,9 @@ export const getActiveTokensLocalStorageKey: (
 ) => string = (account, chainId) =>
   `airswap/activeTokens/${account}/${chainId}`;
 
+export const getCachedMetadataLocalStorageKey = (chainId: number): string =>
+  `airswap/metadataCache/${chainId}`;
+
 export const getAllTokens = async (chainId: number) => {
   let tokens;
   if (!tokensCache[chainId]) {
@@ -21,6 +25,67 @@ export const getAllTokens = async (chainId: number) => {
   // TODO: handle failure.
   tokens = await tokensCache[chainId];
   return tokens;
+};
+
+export const getUnknownTokens = async (
+  chainId: number,
+  supportedTokenAddresses: string[],
+  allTokens: TokenInfo[],
+  provider: providers.Provider
+): Promise<TokenInfo[]> => {
+  const storageKey = getCachedMetadataLocalStorageKey(chainId);
+  // Get a list of all token addresses from token lists
+  const uniqueTokenListAddresses = uniqBy(allTokens, (t) => t.address).map(
+    (t) => t.address
+  );
+
+  // Get any tokens we've previously manually looked up from cache
+  let localStorageTokens: TokenInfo[] = [];
+  const localStorageData = localStorage.getItem(storageKey);
+  if (localStorageData) {
+    try {
+      localStorageTokens = (JSON.parse(localStorageData) as TokenInfo[]).filter(
+        // This filter ensures we don't continue to store tokens that become
+        // unsupported or contained in token lists.
+        (t) =>
+          !uniqueTokenListAddresses.includes(t.address) &&
+          supportedTokenAddresses.includes(t.address)
+      );
+    } catch (e) {
+      localStorage.removeItem(storageKey);
+    }
+  }
+
+  const localStorageTokenAddresses = localStorageTokens.map((t) => t.address);
+  const knownTokens = uniqueTokenListAddresses.concat(
+    localStorageTokenAddresses
+  );
+
+  // Determine tokens we still don't know about.
+  const unknownTokens = supportedTokenAddresses.filter(
+    (supportedTokenAddr) => !knownTokens.includes(supportedTokenAddr)
+  );
+
+  let scrapedTokens: TokenInfo[] = [];
+  if (unknownTokens.length) {
+    // @ts-ignore provider type mismatch w/ metadata repo
+    const scrapePromises = unknownTokens.map((t) => scrapeToken(t, provider));
+    const results = await Promise.allSettled(scrapePromises);
+    scrapedTokens = results
+      .filter((r) => r.status === "fulfilled")
+      .map((r) => {
+        const tokenInfo = (r as PromiseFulfilledResult<TokenInfo>).value;
+        return {
+          ...tokenInfo,
+          address: tokenInfo.address.toLowerCase(),
+        };
+      });
+  }
+
+  localStorageTokens = localStorageTokens.concat(scrapedTokens);
+  localStorage.setItem(storageKey, JSON.stringify(localStorageTokens));
+
+  return localStorageTokens;
 };
 
 export const getActiveTokensFromLocalStorage = (

--- a/src/features/registry/registrySlice.ts
+++ b/src/features/registry/registrySlice.ts
@@ -5,6 +5,10 @@ import uniqBy from "lodash.uniqby";
 
 import { AppDispatch, RootState } from "../../app/store";
 import { getActiveTokensFromLocalStorage } from "../metadata/metadataApi";
+import {
+  setWalletConnected,
+  setWalletDisconnected,
+} from "../wallet/walletSlice";
 import { getStakerTokens } from "./registryAPI";
 
 export interface RegistryState {
@@ -81,7 +85,10 @@ export const registrySlice = createSlice({
       })
       .addCase(fetchSupportedTokens.rejected, (state) => {
         state.status = "failed";
-      });
+      })
+      // Reset on wallet connect or disconnect
+      .addCase(setWalletConnected, () => initialState)
+      .addCase(setWalletDisconnected, () => initialState);
   },
 });
 

--- a/src/features/wallet/Wallet.tsx
+++ b/src/features/wallet/Wallet.tsx
@@ -26,6 +26,7 @@ import {
 import { getTransactionsLocalStorageKey } from "../metadata/metadataApi";
 import {
   fetchAllTokens,
+  fetchUnkownTokens,
   selectActiveTokens,
   selectAllTokenInfo,
 } from "../metadata/metadataSlice";
@@ -113,7 +114,6 @@ export const Wallet: FC<WalletProps> = ({ className = "" }) => {
         })
       );
       saveLastAccount(account, provider);
-      dispatch(fetchAllTokens());
       dispatch(
         requestActiveTokenAllowances({
           provider: library,
@@ -124,11 +124,19 @@ export const Wallet: FC<WalletProps> = ({ className = "" }) => {
           provider: library,
         })
       );
-      dispatch(
+      const allTokensPromise = dispatch(fetchAllTokens());
+      const supportedTokensPromise = dispatch(
         fetchSupportedTokens({
           provider: library,
         })
       );
+      Promise.all([allTokensPromise, supportedTokensPromise]).then(() => {
+        dispatch(
+          fetchUnkownTokens({
+            provider: library,
+          })
+        );
+      });
     } else {
       dispatch(setWalletDisconnected());
     }


### PR DESCRIPTION
Fixes #168

- Waits for tokenLists and supportedTokens to be fetched
- Determines if any supportedTokens don't have TokenInfo from tokenlist
- Fetches missing tokenInfo using `scrapeToken` from `@airswap/metadata`
- Caches metadata in localStorage (`airswap/metadataCache/[chainId]`) and doesn't requests subsequently.

Note that localStorage is automatically freed up on load if either metadata or supportedTokens change such that some previously stored TokenInfo is now extraneous.

At time of PR there are 6 tokens supported in the registry that are not in our Token lists - you can use one of these to test:

```text
0x83f798e925bcd4017eb265844fddabb448f1707d
0x16de59092dae5ccf4a1e6439d611fd0653f0bd01
0xbc5cef436eadacadfa8dafb63088f09f21dea7e9
0xc2cb1040220768554cf699b0d863a3cd4324ce32
0xd6ad7a6750a7593e092a9b218d66c0a814a3436e
0xe6354ed5bc4b393a5aad09f21c46e101e692d447
```