### PR TITLE
Feature/8pt grid

### DIFF
--- a/src/components/Button/Button.styles.tsx
+++ b/src/components/Button/Button.styles.tsx
@@ -43,7 +43,7 @@ export const StyledButton = styled.button<ButtonProps>`
   align-items: center;
   justify-content: ${(props) => props.justifyContent || "center"};
   width: 100%;
-  height: 3.125rem;
+  height: 3rem;
   padding: 0 1rem;
   font-size: 1rem;
   font-weight: 600;

--- a/src/components/SwapWidget/SwapWidget.styles.tsx
+++ b/src/components/SwapWidget/SwapWidget.styles.tsx
@@ -6,7 +6,7 @@ import Button from "../Button/Button";
 import WalletProviderList from "../WalletProviderList/WalletProviderList";
 
 export const Header = styled.div`
-  margin-bottom: 1.875rem;
+  margin-bottom: 2rem;
 `;
 
 export const QuoteAndTimer = styled.div`
@@ -26,32 +26,33 @@ export const InfoContainer = styled.div`
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  height: 11.25rem;
-  margin-top: -0.625rem;
+  flex-grow: 2;
+  margin-bottom: 0.5rem;
 `;
 
 export const ButtonContainer = styled.div`
   display: flex;
-  flex-direction: row;
+  margin-top: auto;
+  justify-self: flex-end;
   gap: 1.25rem;
-  margin-bottom: 2.75rem;
 `;
 
 export const SwapIconContainer = styled.div`
-  position: absolute;
-  /* right: 3.75rem; */
-  right: 14.125rem;
-  top: 10rem;
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 1.75rem;
-  height: 1.75rem;
+  align-self: center;
+  /* right: 3.75rem; */
+  right: 14.125rem;
+  margin-top: -1.5rem;
+  transform: translateY(0.5rem);
+  width: 1.5rem;
+  height: 1.5rem;
   /* margin-top: -1rem; */
   /* margin-bottom: -0.875rem; */
   border: 1px solid ${(props) => props.theme.colors.borderGrey};
   background-color: ${(props) => props.theme.colors.black};
-  font-size: 1.25rem;
+  font-size: 1rem;
   z-index: 1;
 `;
 
@@ -65,6 +66,8 @@ export const Placeholder = styled.div`
 `;
 
 export const StyledSwapWidget = styled.div`
+  display: flex;
+  flex-direction: column;
   height: 100%;
 `;
 

--- a/src/components/TokenSelect/TokenSelect.styles.tsx
+++ b/src/components/TokenSelect/TokenSelect.styles.tsx
@@ -12,6 +12,7 @@ import {
 export const FlexRow = styled.div`
   display: flex;
   flex-direction: row;
+  height: 2.5rem;
 `;
 
 export const AmountAndDetailsContainer = styled.div`
@@ -79,9 +80,9 @@ export const TokenSelectContainer = styled.div<{ isLoading: boolean }>`
   justify-content: space-between;
   position: relative;
   width: 100%;
-  height: 5rem;
-  padding: 1.25em;
-  margin-bottom: 0.625rem;
+  height: 4.5rem;
+  padding: 1rem;
+  margin-bottom: 0.5rem;
   border: 1px solid ${(props) => props.theme.colors.borderGrey};
   border-radius: 2px;
   background-color: ${(props) =>
@@ -122,7 +123,9 @@ export const StyledDownArrow = styled(MdKeyboardArrowDown)<{
 export const StyledSelectButton = styled.button`
   display: flex;
   flex-direction: column;
+  justify-content: center;
   margin-left: 0.9375rem;
+  height: 100%;
   cursor: ${(props) => (props.disabled ? "initial" : "pointer")};
   pointer-events: ${(props) => (props.disabled ? "none" : "visible")};
 
@@ -135,7 +138,8 @@ export const StyledSelectItem = styled(SelectItem)`
   display: flex;
   flex-direction: row;
   align-items: center;
-  gap: 0.5rem;
+  line-height: 1;
+  gap: 0.375rem;
 `;
 
 export const AmountInput = styled(FormInput)<{

--- a/src/components/TradeContainer/TradeContainer.styles.tsx
+++ b/src/components/TradeContainer/TradeContainer.styles.tsx
@@ -24,9 +24,9 @@ export const StyledTradeContainer = styled.div<StyledTradeContainerProps>`
   box-sizing: border-box;
   border-radius: 0.5rem;
   margin: 0 auto;
-  padding: 2.25rem;
+  padding: 2.5rem;
   width: 100%;
-  max-width: 34.5rem;
+  max-width: 35rem;
   background: url("${process.env.PUBLIC_URL}/images/bg.jpg");
   background-size: 100% 100%;
 

--- a/src/components/WalletProviderList/WalletProviderList.styles.tsx
+++ b/src/components/WalletProviderList/WalletProviderList.styles.tsx
@@ -22,7 +22,7 @@ export const StyledButton = styled.button`
   align-items: center;
   position: relative;
   border: 1px solid ${(props) => props.theme.colors.borderGrey};
-  padding: 1rem 1.625rem;
+  padding: 1rem;
   height: 4.5rem;
   background: ${(props) => props.theme.colors.darkGrey};
 
@@ -31,7 +31,7 @@ export const StyledButton = styled.button`
   }
 
   & + & {
-    margin-top: 0.6875rem;
+    margin-top: 0.5rem;
   }
 `;
 

--- a/src/style/sizes.ts
+++ b/src/style/sizes.ts
@@ -1,4 +1,4 @@
 export const sizes = {
   sideBarWidth: "28rem",
-  tradeContainerPadding: "1.875rem",
+  tradeContainerPadding: "2rem",
 };

--- a/src/style/themes.ts
+++ b/src/style/themes.ts
@@ -33,12 +33,12 @@ const typography: DefaultTheme["typography"] = {
   },
   infoHeading: {
     fontSize: "1rem",
-    lineHeight: 1.5625,
+    lineHeight: 1.5,
     fontWeight: 600,
   },
   infoSubHeading: {
     fontSize: "1rem",
-    lineHeight: 1.5625,
+    lineHeight: 1.5,
     fontWeight: 400,
   },
   formLabel: {


### PR DESCRIPTION
Tweaked css of SwapWidget and WalletProdiverSelect to match new 8pt grid design.

![Screenshot 2021-09-26 at 13 52 22](https://user-images.githubusercontent.com/86911296/134806676-da3647c2-ffbc-4742-b056-1ccafc1664ee.png)



Wallet and TokenSelect still needs to be done though:

![Screenshot 2021-09-25 at 11 43 41](https://user-images.githubusercontent.com/86911296/134806750-e4cfbdb5-717c-4b97-a1c0-f23205a7eeb2.png)

![Screenshot 2021-09-25 at 11 48 20](https://user-images.githubusercontent.com/86911296/134806758-edea9503-8316-4f65-b703-400abfd03615.png)

