### PR TITLE
adds a bookmark warning to the top of the app

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -14,5 +14,7 @@
   "failed": "Failed",
   "undefined": "undefined",
   "noResultsFound": "No results found",
-  "done": "Done"
+  "done": "Done",
+  "bookmarkWarning1": "Make sure the URL is {{url}}",
+  "bookmarkWarning2": " - Press (Ctrl+D or Cmd+D) to bookmark it to be safe."
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -35,7 +35,7 @@ const App = (): JSX.Element => {
         {/* Suspense needed here for loading i18n resources */}
         <Suspense fallback={<PageLoader />}>
           <BookmarkWarning
-            hidden={width! < 800 || !showBookmarkWarning}
+            hidden={width! < 480 || !showBookmarkWarning}
             onClick={() => dispatch(disableBookmarkWarning())}
           />
           <Router>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,7 @@ import {
   disableBookmarkWarning,
   selectUserSettings,
 } from "./features/userSettings/userSettingsSlice";
+import useWindowSize from "./helpers/useWindowSize";
 import "./i18n/i18n";
 import GlobalStyle from "./style/GlobalStyle";
 import { darkTheme, lightTheme } from "./style/themes";
@@ -26,6 +27,7 @@ function getLibrary(provider: any): Web3Provider {
 
 const App = (): JSX.Element => {
   const { theme, showBookmarkWarning } = useAppSelector(selectUserSettings);
+  const { width } = useWindowSize();
   const dispatch = useAppDispatch();
   return (
     <ThemeProvider theme={theme === "dark" ? darkTheme : lightTheme}>
@@ -33,7 +35,7 @@ const App = (): JSX.Element => {
         {/* Suspense needed here for loading i18n resources */}
         <Suspense fallback={<PageLoader />}>
           <BookmarkWarning
-            hidden={!showBookmarkWarning}
+            hidden={width! < 800 || !showBookmarkWarning}
             onClick={() => dispatch(disableBookmarkWarning())}
           />
           <Router>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,10 +6,14 @@ import { Web3ReactProvider } from "@web3-react/core";
 
 import { ThemeProvider } from "styled-components/macro";
 
-import { useAppSelector } from "./app/hooks";
+import { useAppDispatch, useAppSelector } from "./app/hooks";
+import BookmarkWarning from "./components/BookmarkWarning/BookmarkWarning";
 import Page from "./components/Page/Page";
 import PageLoader from "./components/PageLoader/PageLoader";
-import { selectUserSettings } from "./features/userSettings/userSettingsSlice";
+import {
+  disableBookmarkWarning,
+  selectUserSettings,
+} from "./features/userSettings/userSettingsSlice";
 import "./i18n/i18n";
 import GlobalStyle from "./style/GlobalStyle";
 import { darkTheme, lightTheme } from "./style/themes";
@@ -21,13 +25,17 @@ function getLibrary(provider: any): Web3Provider {
 }
 
 const App = (): JSX.Element => {
-  const { theme } = useAppSelector(selectUserSettings);
-
+  const { theme, showBookmarkWarning } = useAppSelector(selectUserSettings);
+  const dispatch = useAppDispatch();
   return (
     <ThemeProvider theme={theme === "dark" ? darkTheme : lightTheme}>
       <Web3ReactProvider getLibrary={getLibrary}>
         {/* Suspense needed here for loading i18n resources */}
         <Suspense fallback={<PageLoader />}>
+          <BookmarkWarning
+            hidden={!showBookmarkWarning}
+            onClick={() => dispatch(disableBookmarkWarning())}
+          />
           <Router>
             <Route path="/:tokenFrom?/:tokenTo?">
               <Page />

--- a/src/components/BookmarkWarning/BookmarkWarning.styles.tsx
+++ b/src/components/BookmarkWarning/BookmarkWarning.styles.tsx
@@ -24,14 +24,17 @@ export const StyledBookmarkWarning = styled.div<BookmarkWarningProps>`
   font-size: 1rem;
   font-weight: 600;
   white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+  padding-left: 1rem;
+  padding-right: 3.5rem;
   color: ${(props) => props.theme.colors.alwaysWhite};
   background: ${(props) => props.theme.colors.primary};
   cursor: pointer;
   z-index: 1;
   ${Text} {
     font-weight: normal;
+    text-overflow: ellipsis;
+    text-align: center;
+    overflow: hidden;
   }
   ${ButtonX} {
     font-weight: normal;

--- a/src/components/BookmarkWarning/BookmarkWarning.styles.tsx
+++ b/src/components/BookmarkWarning/BookmarkWarning.styles.tsx
@@ -15,7 +15,7 @@ export const ButtonX = styled.button`
 `;
 
 export const StyledBookmarkWarning = styled.div<BookmarkWarningProps>`
-  height: 2rem;
+  height: 40px;
   display: flex;
   transition: opacity 0.3s ease-out;
   align-items: center;

--- a/src/components/BookmarkWarning/BookmarkWarning.styles.tsx
+++ b/src/components/BookmarkWarning/BookmarkWarning.styles.tsx
@@ -14,7 +14,7 @@ export const ButtonX = styled.button`
   cursor: ${(props) => (props.disabled ? "none" : "pointer")};
 `;
 
-export const StyledBookmarkWarning = styled.button<BookmarkWarningProps>`
+export const StyledBookmarkWarning = styled.div<BookmarkWarningProps>`
   height: 2rem;
   display: flex;
   transition: opacity 0.3s ease-out;
@@ -28,8 +28,7 @@ export const StyledBookmarkWarning = styled.button<BookmarkWarningProps>`
   text-overflow: ellipsis;
   color: ${(props) => props.theme.colors.alwaysWhite};
   background: ${(props) => props.theme.colors.primary};
-  pointer-events: ${(props) => (props.disabled ? "none" : "visible")};
-  cursor: ${(props) => (props.disabled ? "none" : "pointer")};
+  cursor: pointer;
   z-index: 1;
   ${Text} {
     font-weight: normal;

--- a/src/components/BookmarkWarning/BookmarkWarning.styles.tsx
+++ b/src/components/BookmarkWarning/BookmarkWarning.styles.tsx
@@ -1,0 +1,40 @@
+import styled from "styled-components/macro";
+
+import { BookmarkWarningProps } from "./BookmarkWarning";
+
+export const Text = styled.div`
+  transition: opacity 0.3s ease-out;
+`;
+
+export const ButtonX = styled.button`
+  position: absolute;
+  right: 2rem;
+  color: ${(props) => props.theme.colors.alwaysWhite};
+  pointer-events: ${(props) => (props.disabled ? "none" : "visible")};
+  cursor: ${(props) => (props.disabled ? "none" : "pointer")};
+`;
+
+export const StyledBookmarkWarning = styled.button<BookmarkWarningProps>`
+  height: 2rem;
+  display: flex;
+  transition: opacity 0.3s ease-out;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  font-size: 1rem;
+  font-weight: 600;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  color: ${(props) => props.theme.colors.alwaysWhite};
+  background: ${(props) => props.theme.colors.primary};
+  pointer-events: ${(props) => (props.disabled ? "none" : "visible")};
+  cursor: ${(props) => (props.disabled ? "none" : "pointer")};
+  z-index: 1;
+  ${Text} {
+    font-weight: normal;
+  }
+  ${ButtonX} {
+    font-weight: normal;
+  }
+`;

--- a/src/components/BookmarkWarning/BookmarkWarning.tsx
+++ b/src/components/BookmarkWarning/BookmarkWarning.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { useTranslation } from "react-i18next";
 
 import Icon from "../Icon/Icon";
 import { ButtonX, StyledBookmarkWarning, Text } from "./BookmarkWarning.styles";
@@ -8,18 +9,25 @@ export type BookmarkWarningProps = {
    * if hidden, return null so that nothing gets rendered
    */
   hidden?: boolean;
-} & React.ButtonHTMLAttributes<HTMLButtonElement>;
+  /**
+   * A handler for the close action
+   */
+  onClick?: () => void;
+};
 
 export const BookmarkWarning = ({
   hidden = false,
   onClick,
 }: BookmarkWarningProps) => {
+  const { t } = useTranslation(["common"]);
   if (hidden) return null;
+
   return (
     <StyledBookmarkWarning>
       <Text>
-        Make sure the URL is <strong>airswap.io</strong> - Press (Ctrl+D or
-        Cmd+D) to bookmark it to be safe.
+        {t("common:bookmarkWarning1")}
+        <strong>airswap.io</strong>
+        {t("common:bookmarkWarning2")}
       </Text>
       <ButtonX onClick={onClick}>
         <Icon iconSize={1.0} name="button-x" />{" "}

--- a/src/components/BookmarkWarning/BookmarkWarning.tsx
+++ b/src/components/BookmarkWarning/BookmarkWarning.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+
+import Icon from "../Icon/Icon";
+import { ButtonX, StyledBookmarkWarning, Text } from "./BookmarkWarning.styles";
+
+export type BookmarkWarningProps = {
+  /**
+   * if hidden, return null so that nothing gets rendered
+   */
+  hidden?: boolean;
+} & React.ButtonHTMLAttributes<HTMLButtonElement>;
+
+export const BookmarkWarning = ({
+  hidden = false,
+  onClick,
+}: BookmarkWarningProps) => {
+  if (hidden) return null;
+  return (
+    <StyledBookmarkWarning>
+      <Text>
+        Make sure the URL is <strong>airswap.io</strong> - Press (Ctrl+D or
+        Cmd+D) to bookmark it to be safe.
+      </Text>
+      <ButtonX onClick={onClick}>
+        <Icon iconSize={1.0} name="button-x" />{" "}
+      </ButtonX>
+    </StyledBookmarkWarning>
+  );
+};
+
+export default BookmarkWarning;

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -10,6 +10,7 @@ import {
   IconArrowRight,
   IconDarkModeSwitch,
   IconDeny,
+  IconX,
 } from "./icons";
 
 type IconSet = {
@@ -34,6 +35,7 @@ export const icons: IconSet = {
   "transaction-failed": HiX,
   "transaction-pending": MdAccessTime,
   "transaction-link": MdOpenInNew,
+  "button-x": IconX,
 };
 
 interface IconProps extends SvgIconProps {

--- a/src/components/Icon/icons/IconX.tsx
+++ b/src/components/Icon/icons/IconX.tsx
@@ -1,0 +1,14 @@
+import React, { FC, ReactElement } from "react";
+
+import { SvgIconProps } from "../Icon";
+
+const IconX: FC<SvgIconProps> = ({ className = "" }): ReactElement => (
+  <svg fill="none" viewBox="0 0 14 14" className={className}>
+    <path
+      d="M14 1.41L12.59 0L7 5.59L1.41 0L0 1.41L5.59 7L0 12.59L1.41 14L7 8.41L12.59 14L14 12.59L8.41 7L14 1.41Z"
+      fill="white"
+    />
+  </svg>
+);
+
+export default IconX;

--- a/src/components/Icon/icons/index.ts
+++ b/src/components/Icon/icons/index.ts
@@ -2,5 +2,6 @@ import IconArrowLeft from "./IconArrowLeft";
 import IconArrowRight from "./IconArrowRight";
 import IconDarkModeSwitch from "./IconDarkModeSwitch";
 import IconDeny from "./IconDeny";
+import IconX from "./IconX";
 
-export { IconArrowRight, IconArrowLeft, IconDarkModeSwitch, IconDeny };
+export { IconArrowRight, IconArrowLeft, IconDarkModeSwitch, IconDeny, IconX };

--- a/src/components/Page/Page.styles.tsx
+++ b/src/components/Page/Page.styles.tsx
@@ -6,6 +6,7 @@ import { StyledPageProps } from "./Page";
 export const StyledSiteLogo = styled(SiteLogo)`
   position: absolute;
   top: 2.5rem;
+  top: ${(props) => (props.adjustForBookmarkWarning ? "1.5rem" : "2.5rem")};
   left: 2.5rem;
 `;
 

--- a/src/components/Page/Page.styles.tsx
+++ b/src/components/Page/Page.styles.tsx
@@ -1,6 +1,7 @@
 import styled from "styled-components/macro";
 
 import SiteLogo from "../SiteLogo/SiteLogo";
+import { StyledPageProps } from "./Page";
 
 export const StyledSiteLogo = styled(SiteLogo)`
   position: absolute;
@@ -8,18 +9,20 @@ export const StyledSiteLogo = styled(SiteLogo)`
   left: 2.5rem;
 `;
 
-export const StyledPage = styled.div`
+export const StyledPage = styled.div<StyledPageProps>`
   display: flex;
   justify-content: center;
   align-items: center;
   position: relative;
   min-width: 18rem;
-  min-height: 100vh;
+  min-height: ${(props) =>
+    props.adjustForBookmarkWarning ? "calc(100vh - 2rem)" : "100vh"};
   padding: 2rem 0;
 
   @media (min-height: 50rem) {
     align-items: center;
-    height: 100vh;
+    height: ${(props) =>
+      props.adjustForBookmarkWarning ? "calc(100vh - 2rem)" : "100vh"};
     min-height: 50rem;
   }
 `;

--- a/src/components/Page/Page.styles.tsx
+++ b/src/components/Page/Page.styles.tsx
@@ -6,7 +6,7 @@ import { StyledPageProps } from "./Page";
 export const StyledSiteLogo = styled(SiteLogo)`
   position: absolute;
   top: 2.5rem;
-  top: ${(props) => (props.adjustForBookmarkWarning ? "1.5rem" : "2.5rem")};
+  top: ${(props) => (props.adjustForBookmarkWarning ? "1.2rem" : "2.5rem")};
   left: 2.5rem;
 `;
 
@@ -17,13 +17,13 @@ export const StyledPage = styled.div<StyledPageProps>`
   position: relative;
   min-width: 18rem;
   min-height: ${(props) =>
-    props.adjustForBookmarkWarning ? "calc(100vh - 2rem)" : "100vh"};
+    props.adjustForBookmarkWarning ? "calc(100vh - 40px)" : "100vh"};
   padding: 2rem 0;
 
   @media (min-height: 50rem) {
     align-items: center;
     height: ${(props) =>
-      props.adjustForBookmarkWarning ? "calc(100vh - 2rem)" : "100vh"};
+      props.adjustForBookmarkWarning ? "calc(100vh - 40px)" : "100vh"};
     min-height: 50rem;
   }
 `;

--- a/src/components/Page/Page.tsx
+++ b/src/components/Page/Page.tsx
@@ -5,8 +5,13 @@ import React, { FC, ReactElement, useState } from "react";
 
 import { useAppDispatch, useAppSelector } from "../../app/hooks";
 import { Orders } from "../../features/orders/Orders";
-import { selectUserSettings } from "../../features/userSettings/userSettingsSlice";
-import { StyledWallet } from "../SideBar/SideBar.styles";
+import {
+  selectUserSettings,
+  toggleTheme,
+} from "../../features/userSettings/userSettingsSlice";
+import useWindowSize from "../../helpers/useWindowSize";
+import SideBar from "../SideBar/SideBar";
+import { StyledDarkModeSwitch, StyledWallet } from "../SideBar/SideBar.styles";
 import Toaster from "../Toasts/Toaster";
 import TradeContainer from "../TradeContainer/TradeContainer";
 import { StyledPage, StyledSiteLogo } from "./Page.styles";
@@ -21,27 +26,31 @@ export type StyledPageProps = {
 const Page: FC = (): ReactElement => {
   const [sideBarOpen, setSideBarOpen] = useState<boolean>(true);
   const { showBookmarkWarning } = useAppSelector(selectUserSettings);
+  const { width } = useWindowSize();
   const dispatch = useAppDispatch();
+  const adjustForBookmarkWarning = width! > 800 && showBookmarkWarning;
 
   return (
-    <StyledPage adjustForBookmarkWarning={showBookmarkWarning}>
+    <StyledPage adjustForBookmarkWarning={adjustForBookmarkWarning}>
       <Toaster sideBarOpen={sideBarOpen} />
-      <StyledSiteLogo />
+      <StyledSiteLogo adjustForBookmarkWarning={adjustForBookmarkWarning} />
       <StyledWallet isOpen={sideBarOpen} />
       <TradeContainer isOpen={sideBarOpen}>
         <Orders />
       </TradeContainer>
-      {/* <SideBar
+      {/*
+       <SideBar
         isOpen={sideBarOpen}
         setIsOpen={() => {
           setSideBarOpen(!sideBarOpen);
         }}
-      /> */}
-      {/* <StyledDarkModeSwitch
+      />*/}
+      {/*
+       <StyledDarkModeSwitch
         onClick={() => {
           dispatch(toggleTheme());
         }}
-      /> */}
+      />*/}
     </StyledPage>
   );
 };

--- a/src/components/Page/Page.tsx
+++ b/src/components/Page/Page.tsx
@@ -28,7 +28,8 @@ const Page: FC = (): ReactElement => {
   const { showBookmarkWarning } = useAppSelector(selectUserSettings);
   const { width } = useWindowSize();
   const dispatch = useAppDispatch();
-  const adjustForBookmarkWarning = width! > 800 && showBookmarkWarning;
+  /* using 480 from breakpoint size defined at src/style/breakpoints.ts */
+  const adjustForBookmarkWarning = width! > 480 && showBookmarkWarning;
 
   return (
     <StyledPage adjustForBookmarkWarning={adjustForBookmarkWarning}>

--- a/src/components/Page/Page.tsx
+++ b/src/components/Page/Page.tsx
@@ -1,24 +1,30 @@
 // FIXME: remove after sidebar re-added
 
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import React, { FC, ReactElement } from "react";
-import { useState } from "react";
+import React, { FC, ReactElement, useState } from "react";
 
-import { useAppDispatch } from "../../app/hooks";
+import { useAppDispatch, useAppSelector } from "../../app/hooks";
 import { Orders } from "../../features/orders/Orders";
-import { toggleTheme } from "../../features/userSettings/userSettingsSlice";
-import SideBar from "../SideBar/SideBar";
-import { StyledWallet, StyledDarkModeSwitch } from "../SideBar/SideBar.styles";
+import { selectUserSettings } from "../../features/userSettings/userSettingsSlice";
+import { StyledWallet } from "../SideBar/SideBar.styles";
 import Toaster from "../Toasts/Toaster";
 import TradeContainer from "../TradeContainer/TradeContainer";
 import { StyledPage, StyledSiteLogo } from "./Page.styles";
 
+export type StyledPageProps = {
+  /**
+   * if set, take off the space needed for the bookmarkwarning from the min-height and height of StyledPage
+   */
+  adjustForBookmarkWarning: boolean;
+};
+
 const Page: FC = (): ReactElement => {
   const [sideBarOpen, setSideBarOpen] = useState<boolean>(true);
+  const { showBookmarkWarning } = useAppSelector(selectUserSettings);
   const dispatch = useAppDispatch();
 
   return (
-    <StyledPage>
+    <StyledPage adjustForBookmarkWarning={showBookmarkWarning}>
       <Toaster sideBarOpen={sideBarOpen} />
       <StyledSiteLogo />
       <StyledWallet isOpen={sideBarOpen} />

--- a/src/components/PageLoader/PageLoader.tsx
+++ b/src/components/PageLoader/PageLoader.tsx
@@ -14,6 +14,7 @@ const PageLoader: FC = (): ReactElement => {
   const sideBarIsOpen = window.location.pathname.indexOf("swap") !== -1;
   const { showBookmarkWarning } = useAppSelector(selectUserSettings);
   const { width } = useWindowSize();
+  /* using 480 from breakpoint size defined at src/style/breakpoints.ts */
   const adjustForBookmarkWarning = width! > 800 && showBookmarkWarning;
 
   return (

--- a/src/components/PageLoader/PageLoader.tsx
+++ b/src/components/PageLoader/PageLoader.tsx
@@ -3,15 +3,18 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import React, { FC, ReactElement } from "react";
 
+import { useAppSelector } from "../../app/hooks";
+import { selectUserSettings } from "../../features/userSettings/userSettingsSlice";
 import { StyledPage, StyledSiteLogo } from "../Page/Page.styles";
 import { StyledDarkModeSwitch, StyledSideBar } from "../SideBar/SideBar.styles";
 import TradeContainer from "../TradeContainer/TradeContainer";
 
 const PageLoader: FC = (): ReactElement => {
   const sideBarIsOpen = window.location.pathname.indexOf("swap") !== -1;
+  const { showBookmarkWarning } = useAppSelector(selectUserSettings);
 
   return (
-    <StyledPage>
+    <StyledPage adjustForBookmarkWarning={showBookmarkWarning}>
       <StyledSiteLogo />
       <TradeContainer isOpen={true} />
       {/* <StyledSideBar isOpen={sideBarIsOpen} /> */}

--- a/src/components/PageLoader/PageLoader.tsx
+++ b/src/components/PageLoader/PageLoader.tsx
@@ -5,6 +5,7 @@ import React, { FC, ReactElement } from "react";
 
 import { useAppSelector } from "../../app/hooks";
 import { selectUserSettings } from "../../features/userSettings/userSettingsSlice";
+import useWindowSize from "../../helpers/useWindowSize";
 import { StyledPage, StyledSiteLogo } from "../Page/Page.styles";
 import { StyledDarkModeSwitch, StyledSideBar } from "../SideBar/SideBar.styles";
 import TradeContainer from "../TradeContainer/TradeContainer";
@@ -12,10 +13,12 @@ import TradeContainer from "../TradeContainer/TradeContainer";
 const PageLoader: FC = (): ReactElement => {
   const sideBarIsOpen = window.location.pathname.indexOf("swap") !== -1;
   const { showBookmarkWarning } = useAppSelector(selectUserSettings);
+  const { width } = useWindowSize();
+  const adjustForBookmarkWarning = width! > 800 && showBookmarkWarning;
 
   return (
-    <StyledPage adjustForBookmarkWarning={showBookmarkWarning}>
-      <StyledSiteLogo />
+    <StyledPage adjustForBookmarkWarning={adjustForBookmarkWarning}>
+      <StyledSiteLogo adjustForBookmarkWarning={adjustForBookmarkWarning} />
       <TradeContainer isOpen={true} />
       {/* <StyledSideBar isOpen={sideBarIsOpen} /> */}
       {/* <StyledDarkModeSwitch /> */}

--- a/src/components/SiteLogo/SiteLogo.tsx
+++ b/src/components/SiteLogo/SiteLogo.tsx
@@ -4,6 +4,7 @@ import { StyledSiteLogo } from "./SiteLogo.styles";
 
 type SiteLogoProps = {
   className?: string;
+  adjustForBookmarkWarning?: boolean;
 };
 
 const SiteLogo: FC<SiteLogoProps> = ({ className }): ReactElement => {

--- a/src/features/userSettings/helpers/getInitialBookmarkWarning.ts
+++ b/src/features/userSettings/helpers/getInitialBookmarkWarning.ts
@@ -1,0 +1,5 @@
+import { BOOKMARK_WARNING_LOCAL_STORAGE_KEY } from "../userSettingsSlice";
+
+export default function getInitialBookmarkWarning(): boolean {
+  return localStorage[BOOKMARK_WARNING_LOCAL_STORAGE_KEY] !== "disabled";
+}

--- a/src/features/userSettings/userSettingsSlice.ts
+++ b/src/features/userSettings/userSettingsSlice.ts
@@ -3,22 +3,32 @@ import { createSlice } from "@reduxjs/toolkit";
 import { ThemeType } from "styled-components/macro";
 
 import { RootState } from "../../app/store";
+import getInitialBookmarkWarning from "./helpers/getInitialBookmarkWarning";
 import getInitialThemeValue from "./helpers/getInitialThemeValue";
 
 export interface UserSettingsState {
   theme: ThemeType;
+  showBookmarkWarning: boolean;
 }
 
 export const THEME_LOCAL_STORAGE_KEY = "airswap/theme";
+export const BOOKMARK_WARNING_LOCAL_STORAGE_KEY =
+  "airswap/show-bookmark-warning";
 
 const initialState: UserSettingsState = {
   theme: getInitialThemeValue(),
+  showBookmarkWarning: getInitialBookmarkWarning(),
 };
 
 const userSettingsSlice = createSlice({
   name: "userSettings",
   initialState,
   reducers: {
+    disableBookmarkWarning: (state) => {
+      const showBookmarkWarning: boolean = false;
+      localStorage[BOOKMARK_WARNING_LOCAL_STORAGE_KEY] = "disabled";
+      state.showBookmarkWarning = showBookmarkWarning;
+    },
     toggleTheme: (state) => {
       const theme: ThemeType = state.theme === "dark" ? "light" : "dark";
       localStorage[THEME_LOCAL_STORAGE_KEY] = theme;
@@ -29,6 +39,9 @@ const userSettingsSlice = createSlice({
 
 export const selectUserSettings = (state: RootState) => state.userSettings;
 
-export const { toggleTheme } = userSettingsSlice.actions;
+export const {
+  toggleTheme,
+  disableBookmarkWarning,
+} = userSettingsSlice.actions;
 
 export default userSettingsSlice.reducer;


### PR DESCRIPTION
Added a bookmark warning div that displays a bookmark warning as shown in the Figma design.
![bilde](https://user-images.githubusercontent.com/1560743/135749652-aaa17655-8099-46f4-8e8b-2bb26d4691e7.png)

The feature is implemented by pushing the content down by 2 rem units. When displayed, the total page height is shrinked by the same amount to avoid showing a scrollbar. Tested in Firefox and Chrome.