### PR TITLE
[Bugfix] Disconnect Wallet button crashed web app

### DIFF
--- a/src/components/TokenSelection/TokenSelection.tsx
+++ b/src/components/TokenSelection/TokenSelection.tsx
@@ -204,7 +204,7 @@ const TokenSelection = ({
               {[nativeETH[chainId], ...sortedFilteredTokens].map((token) => (
                 <TokenButton
                   showDeleteButton={
-                    token.address !== nativeETH[chainId].address && editMode
+                    editMode && token.address !== nativeETH[chainId].address
                   }
                   token={token}
                   balance={formatUnits(


### PR DESCRIPTION
Found a minor bug that crashes the web app when wallet disconnects. This was because it was checking nativeETH[chainid], when chainId was undefined. switching the order of `&&` fixed the error.

closes #217 