### PR TITLE
[bugfix] Wallet Button closing on click

### DIFF
--- a/src/features/wallet/Wallet.tsx
+++ b/src/features/wallet/Wallet.tsx
@@ -313,7 +313,7 @@ export const Wallet: FC<WalletProps> = ({ className = "" }) => {
 
   const handleSettingsOpen = (state: boolean) => {
     setSettingsOpen(state);
-    setWalletOpen(false);
+    state && setWalletOpen(false);
   };
 
   return (


### PR DESCRIPTION
closes #228 

as a side effect of the settings button event listener, the wallet button was also closing.