### PR TITLE
Fix order api types

### DIFF
--- a/src/components/SwapWidget/SwapWidget.tsx
+++ b/src/components/SwapWidget/SwapWidget.tsx
@@ -504,7 +504,7 @@ const SwapWidget = () => {
           chainId: chainId!,
           senderAmount: baseAmount,
           senderTokenDecimals: baseTokenInfo!.decimals,
-          provider: library,
+          provider: library!,
         })
       );
       await unwrapResult(result);

--- a/src/features/orders/ordersSlice.ts
+++ b/src/features/orders/ordersSlice.ts
@@ -10,7 +10,7 @@ import {
 } from "@reduxjs/toolkit";
 
 import BigNumber from "bignumber.js";
-import { Transaction } from "ethers";
+import { Transaction, providers } from "ethers";
 
 import { AppDispatch, RootState } from "../../app/store";
 import { notifyTransaction } from "../../components/Toasts/ToastController";
@@ -79,7 +79,7 @@ export const deposit = createAsyncThunk(
       chainId: number;
       senderAmount: string;
       senderTokenDecimals: number;
-      provider: any;
+      provider: providers.Web3Provider;
     },
     { getState, dispatch }
   ) => {
@@ -111,7 +111,7 @@ export const deposit = createAsyncThunk(
         };
         dispatch(submitTransaction(transaction));
         params.provider.once(tx.hash, async () => {
-          const receipt = await params.provider.getTransactionReceipt(tx.hash);
+          const receipt = await params.provider.getTransactionReceipt(tx.hash!);
           const state: RootState = getState() as RootState;
           const tokens = Object.values(state.metadata.tokens.all);
           if (receipt.status === 1) {
@@ -128,7 +128,12 @@ export const deposit = createAsyncThunk(
               params.chainId
             );
           } else {
-            dispatch(revertTransaction(receipt.transactionHash));
+            dispatch(
+              revertTransaction({
+                hash: receipt.transactionHash,
+                reason: "Transaction reverted",
+              })
+            );
             notifyTransaction(
               "Deposit",
               transaction,


### PR DESCRIPTION
@codyenokida - I looked into how to get the revert reason from a failed transaction. Your google fu may be stronger than mine, but I came to the conclusion there is no reliable way to do it at present for a number of reasons.

Added to the fact we don't actually display the "reason" for a revert anywhere currently, I hard coded "transaction reverted" as the reason. Let me know if you think there's a better option.

The other changes were straightforward.

Fixes #227