### PR TITLE
Update "swap complete" screen

### DIFF
--- a/public/locales/en/orders.json
+++ b/public/locales/en/orders.json
@@ -37,11 +37,12 @@
   "swapPending": "Prepared to swap",
   "swapMessage": "Accept on your wallet to proceed",
   "wrapMessage": "No protocol fee for ETH/WETH swaps",
-  "submitted": "Submitted!",
+  "submitted": "Transaction Submitted",
   "swapFailed": "Error submitting swap",
   "swapFailedCallToAction": "Please try again",
   "swapRejected": "Price expired",
   "swapRejectedCallToAction": "Please try again",
+  "track": "Track",
   "trackTransaction": "Track this transaction on the top right",
   "editCustomTokens": "Edit Custom Tokens"
 }

--- a/src/components/Page/Page.tsx
+++ b/src/components/Page/Page.tsx
@@ -1,12 +1,12 @@
 import React, { FC, ReactElement, useState } from "react";
 
 import { useAppSelector } from "../../app/hooks";
-import { Orders } from "../../features/orders/Orders";
 import { selectUserSettings } from "../../features/userSettings/userSettingsSlice";
 import useWindowSize from "../../helpers/useWindowSize";
 import InformationModals, {
   InformationType,
 } from "../InformationModals/InformationModals";
+import SwapWidget from "../SwapWidget/SwapWidget";
 import Toaster from "../Toasts/Toaster";
 import Toolbar from "../Toolbar/Toolbar";
 import WidgetFrame from "../WidgetFrame/WidgetFrame";
@@ -24,6 +24,9 @@ const Page: FC = (): ReactElement => {
     activeModalPage,
     setActiveModalPage,
   ] = useState<InformationType | null>(null);
+
+  const [transactionsOpen, setTransactionsOpen] = useState<boolean>(false);
+
   const { showBookmarkWarning } = useAppSelector(selectUserSettings);
   const { width } = useWindowSize();
   /* using 480 from breakpoint size defined at src/style/breakpoints.ts */
@@ -41,9 +44,14 @@ const Page: FC = (): ReactElement => {
     <StyledPage adjustForBookmarkWarning={adjustForBookmarkWarning}>
       <Toaster />
       <Toolbar onButtonClick={onToolbarButtonClick} />
-      <StyledWallet />
+      <StyledWallet
+        showTransactions={transactionsOpen}
+        setShowTransactions={setTransactionsOpen}
+      />
       <WidgetFrame>
-        <Orders />
+        <SwapWidget
+          onTrackTransactionClicked={() => setTransactionsOpen(true)}
+        />
       </WidgetFrame>
       <InformationModals
         onCloseModalClick={onCloseModalClick}

--- a/src/components/SwapWidget/SwapWidget.styles.tsx
+++ b/src/components/SwapWidget/SwapWidget.styles.tsx
@@ -31,7 +31,7 @@ export const ButtonContainer = styled.div`
 
 export const HugeTicks = styled(MdDoneAll)`
   font-size: 8rem;
-  margin: 5rem auto 2px auto;
+  margin: 1rem auto -4rem auto;
 `;
 
 export const StyledSwapWidget = styled.div`

--- a/src/components/SwapWidget/SwapWidget.tsx
+++ b/src/components/SwapWidget/SwapWidget.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useEffect, useContext } from "react";
+import { useState, useMemo, useEffect, useContext, FC } from "react";
 import { useTranslation } from "react-i18next";
 import { useHistory, useRouteMatch } from "react-router-dom";
 
@@ -84,7 +84,9 @@ type SwapType = "swap" | "swapWithWrap" | "wrapOrUnwrap";
 
 const initialBaseAmount = "";
 
-const SwapWidget = () => {
+const SwapWidget: FC<{ onTrackTransactionClicked: () => void }> = ({
+  onTrackTransactionClicked,
+}) => {
   // Redux
   const dispatch = useAppDispatch();
   const history = useHistory();
@@ -595,6 +597,10 @@ const SwapWidget = () => {
         } else if (swapType === "wrapOrUnwrap") {
           await doWrap();
         }
+        break;
+
+      case ButtonActions.trackTransaction:
+        onTrackTransactionClicked();
         break;
 
       default:

--- a/src/components/SwapWidget/subcomponents/ActionButtons/ActionButtons.tsx
+++ b/src/components/SwapWidget/subcomponents/ActionButtons/ActionButtons.tsx
@@ -13,6 +13,7 @@ export enum ButtonActions {
   approve,
   requestQuotes,
   takeQuote,
+  trackTransaction,
 }
 
 const buttonTextMapping: Record<ButtonActions, string> = {
@@ -23,6 +24,7 @@ const buttonTextMapping: Record<ButtonActions, string> = {
   [ButtonActions.approve]: "orders:approve",
   [ButtonActions.requestQuotes]: "orders:continue",
   [ButtonActions.takeQuote]: "orders:take",
+  [ButtonActions.trackTransaction]: "orders:track",
 };
 
 /**
@@ -77,6 +79,10 @@ const ActionButtons: FC<{
   else if (hasQuote) nextAction = ButtonActions.takeQuote;
   else nextAction = ButtonActions.requestQuotes;
 
+  // If a secondary action is defined, a secondary button will be displayed.
+  let secondaryAction: ButtonActions | null = null;
+  if (orderComplete) secondaryAction = ButtonActions.trackTransaction;
+
   // If there's something to fix before progress can be made, the button will
   // be disabled. These disabled states never have a back button.
   let isDisabled =
@@ -110,12 +116,26 @@ const ActionButtons: FC<{
     mainButtonText = t(buttonTextMapping[nextAction]);
   }
 
+  let secondaryButtonText: string | null = !!secondaryAction
+    ? // @ts-ignore dynamic translation key.
+      t(buttonTextMapping[secondaryAction])
+    : null;
+
   return (
     <>
       {hasBackButton && (
         <BackButton onClick={onButtonClicked.bind(null, ButtonActions.goBack)}>
           {t("common:back")}
         </BackButton>
+      )}
+      {secondaryAction && (
+        // Note MainButton used to ensure secondary button is same size as main
+        <MainButton
+          intent="neutral"
+          onClick={onButtonClicked.bind(null, secondaryAction)}
+        >
+          {secondaryButtonText}
+        </MainButton>
       )}
       <MainButton
         intent={nextAction === ButtonActions.goBack ? "neutral" : "primary"}

--- a/src/features/orders/Orders.tsx
+++ b/src/features/orders/Orders.tsx
@@ -1,5 +1,0 @@
-import SwapWidget from "../../components/SwapWidget/SwapWidget";
-
-export function Orders() {
-  return <SwapWidget />;
-}

--- a/src/features/wallet/Wallet.tsx
+++ b/src/features/wallet/Wallet.tsx
@@ -60,7 +60,10 @@ import {
   setWalletDisconnected,
 } from "./walletSlice";
 
-export const Wallet: FC = () => {
+export const Wallet: FC<{
+  showTransactions: boolean;
+  setShowTransactions: (value: boolean) => void;
+}> = ({ showTransactions, setShowTransactions }) => {
   const {
     chainId,
     account,
@@ -87,9 +90,6 @@ export const Wallet: FC = () => {
   const [connector, setConnector] = useState<AbstractConnector>();
   const [provider, setProvider] = useState<WalletProvider>();
   const [activated, setActivated] = useState(false);
-  const [transactionsTabOpen, setTransactionsTabOpen] = useState<boolean>(
-    false
-  );
   const [lightContract, setLightContract] = useState<Contract>();
 
   useBeforeunload(() => {
@@ -294,7 +294,7 @@ export const Wallet: FC = () => {
   }, [chainId, dispatch, library, account]);
 
   const handleWalletOpen = (state: boolean) => {
-    setTransactionsTabOpen(state);
+    setShowTransactions(state);
   };
 
   const handleSettingsOpen = (state: boolean) => {
@@ -331,15 +331,15 @@ export const Wallet: FC = () => {
       <TransactionsTab
         address={account!}
         chainId={chainId!}
-        open={transactionsTabOpen}
-        setTransactionsTabOpen={setTransactionsTabOpen}
+        open={showTransactions}
+        setTransactionsTabOpen={setShowTransactions}
         onDisconnectWalletClicked={() => {
           clearLastAccount();
           deactivate();
           if (connector instanceof WalletConnectConnector) {
             connector.close();
           }
-          setTransactionsTabOpen(false);
+          setShowTransactions(false);
         }}
         transactions={transactions}
         tokens={allTokens}


### PR DESCRIPTION
Fixes #295 

- Adds secondary button functionality to `ActionButtons`, and adds secondary "Track" button on swap complete
- Fixes margins on huge ticks to fit with designs
- Extracts transaction open state to page level so that `SwapWidget` can open the drawer.
- Fixes wording
- Removes extraneous `orders.tsx`

![image](https://user-images.githubusercontent.com/82473383/140427023-732d90da-79a2-412e-b28f-4316bad2b297.png)
