### PR TITLE
modifies transaction key

### DIFF
--- a/src/components/TransactionsTab/TransactionsTab.tsx
+++ b/src/components/TransactionsTab/TransactionsTab.tsx
@@ -140,7 +140,7 @@ const TransactionsTab = ({
                   transaction={transaction}
                   tokens={tokens}
                   chainId={chainId!}
-                  key={`${transaction.hash}${transaction.nonce}`}
+                  key={`${transaction.hash}-${transaction.nonce}`}
                 />
               ))
             ) : (

--- a/src/components/TransactionsTab/TransactionsTab.tsx
+++ b/src/components/TransactionsTab/TransactionsTab.tsx
@@ -140,7 +140,7 @@ const TransactionsTab = ({
                   transaction={transaction}
                   tokens={tokens}
                   chainId={chainId!}
-                  key={transaction.hash}
+                  key={`${transaction.hash}${transaction.nonce}`}
                 />
               ))
             ) : (


### PR DESCRIPTION
Not all transactions have a hash, so those end up key-less (with an error in the console). This fix concats the hash with a nonce so that they'll have a unique key. Vice versa, not all transactions have a nonce, so you can't rely on that either. But they all have either one.