### PR TITLE
replaces leading zeros with a single zero

### DIFF
--- a/src/components/SwapWidget/subcomponents/SwapInputs/SwapInputs.tsx
+++ b/src/components/SwapWidget/subcomponents/SwapInputs/SwapInputs.tsx
@@ -58,6 +58,7 @@ const SwapInputs: FC<{
     if (value === "" || floatRegExp.test(value)) {
       if (value[value.length - 1] === ",")
         value = value.slice(0, value.length - 1) + ".";
+      value = value.replace(/^0+/, "0");
       onBaseAmountChange(value);
     }
   };


### PR DESCRIPTION
This regex strips all leading zeros and replaces it with a single one.

I've checked with a few dexes and some allows multiple leading zeros, some no zeroes at all before the dot. So I guess this strikes a balance between the two approaches. You're still allowed to have one leading zero, so you can write `01234.01234`. 

Closes #334 