### PR TITLE
Prevent showing approve button unneccessarily

### DIFF
--- a/public/locales/en/balances.json
+++ b/public/locales/en/balances.json
@@ -2,5 +2,7 @@
   "tokenBalances": "Token balances",
   "addToTokenSet": "Import",
   "unsupportedToken": "Not yet supported",
-  "balance": "Balance"
+  "balance": "Balance",
+  "failedToFetchAllowances": "Failed to fetch token allowances",
+  "failedToFetchAllowancesCta": "Please reload the page"
 }

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -24,5 +24,6 @@
   "vote": "vote",
   "build": "build",
   "about": "about",
-  "join": "join"
+  "join": "join",
+  "reloadPage": "Reload Page"
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,10 +18,14 @@ import "./i18n/i18n";
 import GlobalStyle from "./style/GlobalStyle";
 import { darkTheme, lightTheme } from "./style/themes";
 
+let cachedLibrary: Web3Provider | null;
+
 function getLibrary(provider: any): Web3Provider {
-  const library = new Web3Provider(provider);
-  library.pollingInterval = 12000;
-  return library;
+  if (!cachedLibrary) {
+    cachedLibrary = new Web3Provider(provider);
+    cachedLibrary.pollingInterval = 12000;
+  }
+  return cachedLibrary;
 }
 //1e+9 is the highest possible number
 BigNumber.config({ EXPONENTIAL_AT: 1e9 });

--- a/src/components/Page/Page.tsx
+++ b/src/components/Page/Page.tsx
@@ -10,7 +10,9 @@ import Toolbar from "../Toolbar/Toolbar";
 import WidgetFrame from "../WidgetFrame/WidgetFrame";
 import { StyledPage, StyledWallet } from "./Page.styles";
 
-const Page: FC = (): ReactElement => {
+const Page: FC<{ excludeWallet?: boolean }> = ({
+  excludeWallet,
+}): ReactElement => {
   const [
     activeModalPage,
     setActiveModalPage,

--- a/src/components/SwapWidget/InfoSection.tsx
+++ b/src/components/SwapWidget/InfoSection.tsx
@@ -25,6 +25,7 @@ export type InfoSectionProps = {
   isFetchingOrders: boolean;
   isApproving: boolean;
   isSwapping: boolean;
+  failedToFetchAllowances: boolean;
   bestTradeOption:
     | {
         protocol: "last-look";
@@ -51,6 +52,7 @@ const InfoSection: FC<InfoSectionProps> = ({
   orderSubmitted,
   isApproving,
   isSwapping,
+  failedToFetchAllowances,
   bestTradeOption,
   isWrapping,
   isFetchingOrders,
@@ -60,7 +62,7 @@ const InfoSection: FC<InfoSectionProps> = ({
   quoteTokenInfo,
   onFeeButtonClick,
 }) => {
-  const { t } = useTranslation(["orders", "marketing"]);
+  const { t } = useTranslation(["orders", "marketing", "balances"]);
   const [invertPrice, setInvertPrice] = useState<boolean>(false);
   // Wallet not connected.
   if (!isConnected) {
@@ -68,6 +70,17 @@ const InfoSection: FC<InfoSectionProps> = ({
       <>
         <InfoHeading>{t("marketing:useAtOwnRisk")}</InfoHeading>
         <InfoSubHeading>{t("marketing:alphaPreview")}</InfoSubHeading>
+      </>
+    );
+  }
+
+  if (failedToFetchAllowances) {
+    return (
+      <>
+        <InfoHeading>{t("balances:failedToFetchAllowances")}</InfoHeading>
+        <InfoSubHeading>
+          {t("balances:failedToFetchAllowancesCta")}
+        </InfoSubHeading>
       </>
     );
   }

--- a/src/components/SwapWidget/SwapWidget.tsx
+++ b/src/components/SwapWidget/SwapWidget.tsx
@@ -242,6 +242,10 @@ const SwapWidget: FC<SwapWidgetPropsType> = ({
     return pendingApprovals.some((tx) => tx.tokenAddress === tokenId);
   };
 
+  const allowanceFetchFailed =
+    allowances.light.status === "failed" ||
+    allowances.wrapper.status === "failed";
+
   const hasSufficientAllowance = (tokenAddress: string | undefined) => {
     if (tokenAddress === nativeETH[chainId || 1].address) return true;
     if (!tokenAddress) return false;
@@ -579,6 +583,10 @@ const SwapWidget: FC<SwapWidgetPropsType> = ({
         setBaseAmount(initialBaseAmount);
         break;
 
+      case ButtonActions.reloadPage:
+        window.location.reload();
+        break;
+
       case ButtonActions.connectWallet:
         setShowWalletList(true);
         break;
@@ -681,7 +689,7 @@ const SwapWidget: FC<SwapWidgetPropsType> = ({
                 ? baseAmount
                 : tradeTerms.quoteAmount || bestTradeOption?.quoteAmount || ""
             }
-            disabled={!active}
+            disabled={!active || allowanceFetchFailed}
             readOnly={
               !!bestTradeOption ||
               isWrapping ||
@@ -700,6 +708,7 @@ const SwapWidget: FC<SwapWidgetPropsType> = ({
             isFetchingOrders={isRequestingQuotes}
             isApproving={isApproving}
             isSwapping={isSwapping}
+            failedToFetchAllowances={allowanceFetchFailed}
             // @ts-ignore
             bestTradeOption={bestTradeOption}
             requiresApproval={
@@ -719,6 +728,7 @@ const SwapWidget: FC<SwapWidgetPropsType> = ({
               unsupportedNetwork={
                 !!web3Error && web3Error instanceof UnsupportedChainIdError
               }
+              requiresReload={allowanceFetchFailed}
               orderComplete={showOrderSubmitted}
               baseTokenInfo={baseTokenInfo}
               quoteTokenInfo={quoteTokenInfo}

--- a/src/components/SwapWidget/subcomponents/ActionButtons/ActionButtons.tsx
+++ b/src/components/SwapWidget/subcomponents/ActionButtons/ActionButtons.tsx
@@ -11,6 +11,7 @@ export enum ButtonActions {
   restart,
   goBack,
   approve,
+  reloadPage,
   requestQuotes,
   takeQuote,
   trackTransaction,
@@ -19,6 +20,7 @@ export enum ButtonActions {
 const buttonTextMapping: Record<ButtonActions, string> = {
   [ButtonActions.connectWallet]: "wallet:connectWallet",
   [ButtonActions.switchNetwork]: "wallet:switchNetwork",
+  [ButtonActions.reloadPage]: "common:reloadPage",
   [ButtonActions.restart]: "orders:newSwap",
   [ButtonActions.goBack]: "common:back",
   [ButtonActions.approve]: "orders:approve",
@@ -42,6 +44,7 @@ const buttonTextMapping: Record<ButtonActions, string> = {
 const ActionButtons: FC<{
   walletIsActive: boolean;
   unsupportedNetwork: boolean;
+  requiresReload: boolean;
   orderComplete: boolean;
   pairUnavailable: boolean;
   hasQuote: boolean;
@@ -55,6 +58,7 @@ const ActionButtons: FC<{
 }> = ({
   walletIsActive,
   unsupportedNetwork,
+  requiresReload,
   orderComplete,
   pairUnavailable,
   hasQuote,
@@ -72,6 +76,7 @@ const ActionButtons: FC<{
   let nextAction: ButtonActions;
   // Note that wallet is not considered "active" if connected to wrong network
   if (unsupportedNetwork) nextAction = ButtonActions.switchNetwork;
+  else if (requiresReload) nextAction = ButtonActions.reloadPage;
   else if (!walletIsActive) nextAction = ButtonActions.connectWallet;
   else if (pairUnavailable) nextAction = ButtonActions.goBack;
   else if (orderComplete) nextAction = ButtonActions.restart;
@@ -87,6 +92,7 @@ const ActionButtons: FC<{
   // be disabled. These disabled states never have a back button.
   let isDisabled =
     walletIsActive &&
+    !requiresReload &&
     (!hasSufficientBalance || !baseTokenInfo || !quoteTokenInfo || !hasAmount);
 
   // Some actions require an additional back button

--- a/src/constants/supportedWalletProviders.ts
+++ b/src/constants/supportedWalletProviders.ts
@@ -11,28 +11,38 @@ export type WalletProvider = {
   getConnector: () => AbstractConnector;
 };
 
+const cachedConnectors: Record<string, AbstractConnector> = {};
+
 const SUPPORTED_WALLET_PROVIDERS: WalletProvider[] = [
   {
     name: "MetaMask",
     logo: metamaskLogo,
-    getConnector: () =>
-      new InjectedConnector({
-        supportedChainIds: [
-          1, // Mainet
-          4, // Rinkeby
-        ],
-      }),
+    getConnector: () => {
+      if (!cachedConnectors.MetaMask) {
+        cachedConnectors.MetaMask = new InjectedConnector({
+          supportedChainIds: [
+            1, // Mainet
+            4, // Rinkeby
+          ],
+        });
+      }
+      return cachedConnectors.MetaMask;
+    },
   },
   {
     name: "WalletConnect",
     logo: walletconnectLogo,
-    getConnector: () =>
-      new WalletConnectConnector({
-        rpc: {
-          1: process.env.REACT_APP_RPC_URL_1 || "",
-          4: process.env.REACT_APP_RPC_URL_4 || "",
-        },
-      }),
+    getConnector: () => {
+      if (!cachedConnectors.WalletConect) {
+        cachedConnectors.MetaMask = new WalletConnectConnector({
+          rpc: {
+            1: process.env.REACT_APP_RPC_URL_1 || "",
+            4: process.env.REACT_APP_RPC_URL_4 || "",
+          },
+        });
+      }
+      return cachedConnectors.WalletConect;
+    },
   },
 ];
 

--- a/src/features/balances/balancesSlice.ts
+++ b/src/features/balances/balancesSlice.ts
@@ -95,8 +95,7 @@ const getThunk: (
         }));
       } catch (e: any) {
         console.error(`Error fetching ${type}: ` + e.message);
-        // TODO: error handling
-        return [];
+        throw e;
       }
     },
     {


### PR DESCRIPTION
Closes #349 

In rare cases, the call to fetch ERC20 token allowances for our contracts may fail. This is a failure that could cause a user to waste funds on gas re-approving tokens that are already approved.

This PR provides an interim fix by not allowing the user to proceed following a failed allowances request. The SwapWidget becomes disabled, and the Info text informs the user that fetching token allowances has failed, and that they'll need to reload the page. The action button becomes a "Reload Page" button.

The best way to test this is to short circuit the allowance check by throwing an error on line 77 of `balancesSlice.tsx`.

As a bonus, this PR also fixes the fact that balances and allowances are requested three times on every page load because new `connector` and `provider` objects are created on every render of `Wallet.tsx`. This may improve efficiency elsewhere in the app too.