### PR TITLE
Social links changes

### DIFF
--- a/src/components/SocialButtons/SocialButtons.styles.tsx
+++ b/src/components/SocialButtons/SocialButtons.styles.tsx
@@ -43,6 +43,9 @@ export const SocialButton = styled.div<{ showLocales: number }>`
   justify-content: flex-end;
   width: 2.5rem;
   height: ${({ showLocales }) => (1 + showLocales) * 2.5 + "rem"};
+  &:hover {
+    background-color: ${(props) => props.theme.colors.black};
+  }
 `;
 
 export const StyledIcon = styled(Icon)<{ $deEmphasize: boolean }>`

--- a/src/components/SocialButtons/SocialButtons.styles.tsx
+++ b/src/components/SocialButtons/SocialButtons.styles.tsx
@@ -35,7 +35,7 @@ export const PlainLink = styled(Link)<{ $deEmphasize: boolean }>`
   opacity: ${({ $deEmphasize }) => ($deEmphasize ? 0.5 : 1)};
 `;
 
-export const SocialButton = styled.a<{ showLocales: number }>`
+export const SocialButton = styled.div<{ showLocales: number }>`
   ${BorderedPill}
   ${InputOrButtonBorderStyle}
   display: flex;

--- a/src/components/SocialButtons/SocialButtons.tsx
+++ b/src/components/SocialButtons/SocialButtons.tsx
@@ -44,43 +44,45 @@ const SocialButtons: FC<{}> = () => {
 
   return (
     <Container>
-      {destinations.map((dest) => (
-        <SocialButton
-          href={dest.primary}
-          key={dest.icon}
-          onPointerEnter={setHoveredIcon.bind(null, dest.icon)}
-          onPointerLeave={setHoveredIcon.bind(null, null)}
-          showLocales={
-            hoveredIcon === dest.icon
-              ? Object.keys(dest.locales || {}).length
-              : 0
-          }
-        >
-          {hoveredIcon === dest.icon && (
-            <>
-              {Object.keys(dest.locales || {}).map((locale) => (
-                <PlainLink
-                  onPointerEnter={setHoveredLocale.bind(null, locale)}
-                  onPointerLeave={setHoveredLocale.bind(null, null)}
-                  $deEmphasize={
-                    hoveredLocale !== null && hoveredLocale !== locale
-                  }
-                  href={dest.locales?.[locale]}
-                  key={`${dest.icon}-${locale}`}
-                >
-                  {locale}
-                </PlainLink>
-              ))}
-              <Divider />
-            </>
-          )}
-          <StyledIcon
-            iconSize={1}
-            name={dest.icon}
-            $deEmphasize={hoveredIcon !== null && hoveredIcon !== dest.icon}
-          />
-        </SocialButton>
-      ))}
+      {destinations.map((dest) => {
+        const locales = Object.keys(dest.locales || {});
+        return (
+          <SocialButton
+            key={dest.icon}
+            onPointerEnter={setHoveredIcon.bind(null, dest.icon)}
+            onPointerLeave={setHoveredIcon.bind(null, null)}
+            showLocales={hoveredIcon === dest.icon ? locales.length : 0}
+          >
+            {hoveredIcon === dest.icon && locales.length !== 0 && (
+              <>
+                {locales.map((locale) => (
+                  <PlainLink
+                    onPointerEnter={setHoveredLocale.bind(null, locale)}
+                    onPointerLeave={setHoveredLocale.bind(null, null)}
+                    $deEmphasize={
+                      hoveredLocale !== null && hoveredLocale !== locale
+                    }
+                    href={dest.locales?.[locale]}
+                    key={`${dest.icon}-${locale}`}
+                    target="_blank"
+                    rel="noreferrer"
+                  >
+                    {locale}
+                  </PlainLink>
+                ))}
+                <Divider />
+              </>
+            )}
+            <a href={dest.primary} target="_blank" rel="noreferrer">
+              <StyledIcon
+                iconSize={1}
+                name={dest.icon}
+                $deEmphasize={hoveredIcon !== null && hoveredIcon !== dest.icon}
+              />
+            </a>
+          </SocialButton>
+        );
+      })}
     </Container>
   );
 };


### PR DESCRIPTION
- Fixes link nested in link (caused console error in best case)
- Removes divider that was appearing on hovering even if there were no locales
- Adds a black background on hover to cover the case that the widget is being overlapped by the locales list

Doesn't address the active state when clicking a link (which I think is pretty minor) but otherwise closes #350 - @piersss if you have a good way to deal with the focus problem then please feel free to add it to this PR.

Finally mobile experience needs work here as it's hard to get to the French twitter - not sure of an easy way around this - ideally want to tap once to open the locales list on mobile, but maintain behaviour on desktop.