### PR TITLE
Fix fee calculations

### DIFF
--- a/public/locales/en/validatorErrors.json
+++ b/public/locales/en/validatorErrors.json
@@ -8,7 +8,7 @@
   "invalid_sig": "Invalid signature",
   "expiry_passed": "Order has expired",
   "unauthorized": "Signer has not authorized the signatory",
-  "signer_allowance_low": "Signer has not approved the signer amount",
+  "signer_allowance_low": "Signer does not have enough balance",
   "signer_balance_low": "Signer has not approved the signer amount",
   "nonce_aleady_used": "Nonce has been already used or cancelled",
   "unableSwap": "Unable to swap",

--- a/src/components/TransactionsTab/subcomponents/WalletTransaction/WalletTransaction.tsx
+++ b/src/components/TransactionsTab/subcomponents/WalletTransaction/WalletTransaction.tsx
@@ -4,6 +4,8 @@ import { findTokenByAddress } from "@airswap/metadata";
 import { TokenInfo } from "@airswap/types";
 import { formatUnits } from "@ethersproject/units";
 
+import BigNumber from "bignumber.js";
+
 import {
   SubmittedApproval,
   SubmittedOrder,
@@ -76,6 +78,16 @@ const WalletTransaction = ({
       tokens,
       chainId
     );
+
+    // For last look transactions, the user has sent the signer amount plus
+    // the fee:
+    let signerAmountWithFee: string | null = null;
+    if (tx.protocol === "last-look") {
+      signerAmountWithFee = new BigNumber(tx.order.signerAmount)
+        .multipliedBy(1.0007)
+        .integerValue(BigNumber.ROUND_FLOOR)
+        .toString();
+    }
     return (
       <Container>
         <TextContainer>
@@ -95,7 +107,10 @@ const WalletTransaction = ({
                     senderToken: senderToken.symbol,
                     signerAmount: parseFloat(
                       Number(
-                        formatUnits(tx.order.signerAmount, signerToken.decimals)
+                        formatUnits(
+                          signerAmountWithFee || tx.order.signerAmount,
+                          signerToken.decimals
+                        )
                       ).toFixed(5)
                     ),
                     signerToken: signerToken.symbol,

--- a/src/contexts/lastLook/LastLook.tsx
+++ b/src/contexts/lastLook/LastLook.tsx
@@ -123,6 +123,9 @@ const LastLookProvider: FC = ({ children }) => {
         throw new Error("No quote amount specified");
       const baseAmountAtomic = new BigNumber(terms.baseAmount)
         .multipliedBy(10 ** terms.baseToken.decimals)
+        // Note that we remove the signer fee from the amount that we send.
+        // This was already done to determine quoteAmount.
+        .dividedBy(terms.side === "sell" ? 1.0007 : 1)
         .integerValue(BigNumber.ROUND_CEIL)
         .toString();
       const quoteAmountAtomic = new BigNumber(terms.quoteAmount!)

--- a/src/features/pricing/pricingApi.ts
+++ b/src/features/pricing/pricingApi.ts
@@ -27,7 +27,7 @@ export const calculateQuoteAmount: (params: {
       throw new Error("formulaic pricing not yet supported");
     }
     const signerAmount = new BigNumber(baseAmount)
-      .multipliedBy(1 - parseInt(signerFee) / 1000)
+      .dividedBy(1.0007)
       // .integerValue(BigNumber.ROUND_CEIL)
       .toString();
 
@@ -49,7 +49,7 @@ export const calculateQuoteAmount: (params: {
     const signerAmount = new BigNumber(
       calculateCostFromLevels(senderAmount, levels)
     )
-      .multipliedBy(1 + parseInt(signerFee) / 1000)
+      .multipliedBy(1.0007)
       // .integerValue(BigNumber.ROUND_FLOOR)
       .toString();
     return signerAmount;


### PR DESCRIPTION
Fixes #362 

The issues:

1. When last look orders were being generated, the entered amount was being used for the `signerAmount`, instead of `signerAmount + fee`. This would result in failed swaps if a user's max balance was used.
2. Fee calculations were using fees that were one order of magnitude too big (0.7% instead of 0.07%). This resulted in quote amounts that were too small.

To reproduce the issues (before checking out this branch):

1. Try to swap your max WETH for DAI on rinkeby. You'll hit the validator error saying you have insufficient balance (note the text is wrong!)
2. Swap less than your max balance and look at the actual amounts sent and received.

To verify this works, checkout the branch and swap your max WETH balance for DAI on rinkeby. You should be left with exactly zero WETH, and receive exactly the amount quoted.

Also updates the WalletTransaction to include `signerFee` in the from amount for last look swaps.