### PR TITLE
Fix/357 move modals to overlay

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "@types/react-dom": "^17.0.9",
     "@types/react-redux": "^7.1.18",
     "@types/styled-components": "^5.1.12",
-    "@types/styled-react-modal": "^1.2.1",
     "@web3-react/core": "^6.1.9",
     "@web3-react/injected-connector": "^6.0.7",
     "@web3-react/walletconnect-connector": "6.2.4",
@@ -59,7 +58,6 @@
     "react-scripts": "4.0.3",
     "string_decoder": "^1.3.0",
     "styled-components": "^5.3.1",
-    "styled-react-modal": "^2.1.0",
     "truncate-eth-address": "^1.0.2",
     "typescript": "^4.4.3"
   },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,7 +6,6 @@ import { Web3ReactProvider } from "@web3-react/core";
 
 import BigNumber from "bignumber.js";
 import { ThemeProvider, ThemeType } from "styled-components/macro";
-import { ModalProvider } from "styled-react-modal";
 
 import { useAppSelector } from "./app/hooks";
 import Page from "./components/Page/Page";
@@ -36,16 +35,14 @@ const App = (): JSX.Element => {
     <ThemeProvider theme={renderedTheme === "dark" ? darkTheme : lightTheme}>
       <Web3ReactProvider getLibrary={getLibrary}>
         <LastLookProvider>
-          <ModalProvider>
-            {/* Suspense needed here for loading i18n resources */}
-            <Suspense fallback={<PageLoader />}>
-              <Router>
-                <Route path="/:tokenFrom?/:tokenTo?">
-                  <Page />
-                </Route>
-              </Router>
-            </Suspense>
-          </ModalProvider>
+          {/* Suspense needed here for loading i18n resources */}
+          <Suspense fallback={<PageLoader />}>
+            <Router>
+              <Route path="/:tokenFrom?/:tokenTo?">
+                <Page />
+              </Route>
+            </Router>
+          </Suspense>
         </LastLookProvider>
       </Web3ReactProvider>
       <GlobalStyle />

--- a/src/components/InformationModals/InformationModals.tsx
+++ b/src/components/InformationModals/InformationModals.tsx
@@ -9,34 +9,19 @@ import {
 } from "../../styled-components/Modal/Modal";
 import JoinModal from "./subcomponents/JoinModal/JoinModal";
 
-export type InformationType = "stats" | "about" | "join";
+export type InformationPageType = "stats" | "join";
 
-type InformationModalProps = {
-  activeModal: InformationType | null;
-  onCloseModalClick: () => void;
+type InformationPageProps = {
+  activeModal: InformationPageType | null;
 };
 
-const InformationModals: FC<InformationModalProps> = ({
+const InformationModals: FC<InformationPageProps> = ({
   activeModal,
-  onCloseModalClick,
 }) => {
-  // TODO: For some reason StyledModal doesn't inherit theme, so we have to import it again here.
-  const theme = useAppSelector(selectTheme);
-
   return (
-    <StyledModal
-      theme={theme === "dark" ? darkTheme : lightTheme}
-      isOpen={!!activeModal}
-      onBackgroundClick={onCloseModalClick}
-      onEscapeKeydown={onCloseModalClick}
-    >
+    <>
       {activeModal === "join" && <JoinModal />}
-      <ModalCloseButton
-        icon="exit-modal"
-        iconSize={1.5}
-        onClick={onCloseModalClick}
-      />
-    </StyledModal>
+    </>
   );
 };
 

--- a/src/components/InformationModals/InformationModals.tsx
+++ b/src/components/InformationModals/InformationModals.tsx
@@ -1,28 +1,15 @@
 import React, { FC } from "react";
 
-import { useAppSelector } from "../../app/hooks";
-import { selectTheme } from "../../features/userSettings/userSettingsSlice";
-import { darkTheme, lightTheme } from "../../style/themes";
-import {
-  ModalCloseButton,
-  StyledModal,
-} from "../../styled-components/Modal/Modal";
 import JoinModal from "./subcomponents/JoinModal/JoinModal";
 
-export type InformationPageType = "stats" | "join";
+export type InformationModalType = "stats" | "join";
 
-type InformationPageProps = {
-  activeModal: InformationPageType | null;
+type InformationModalProps = {
+  activeModal: InformationModalType | null;
 };
 
-const InformationModals: FC<InformationPageProps> = ({
-  activeModal,
-}) => {
-  return (
-    <>
-      {activeModal === "join" && <JoinModal />}
-    </>
-  );
+const InformationModals: FC<InformationModalProps> = ({ activeModal }) => {
+  return <>{activeModal === "join" && <JoinModal />}</>;
 };
 
 export default InformationModals;

--- a/src/components/InformationModals/subcomponents/GuideButton/GuideButton.styles.tsx
+++ b/src/components/InformationModals/subcomponents/GuideButton/GuideButton.styles.tsx
@@ -9,7 +9,7 @@ export const StyledIcon = styled(Icon)`
 `;
 
 export const Text = styled.div`
-  font-size: 0.75rem;
+  font-size: 0.675rem;
   font-weight: 700;
   text-transform: uppercase;
   line-height: 2;
@@ -25,7 +25,7 @@ export const GuideButtonContainer = styled.a`
   border: 1px solid ${(props) => props.theme.colors.borderGrey};
   padding: 1rem;
   width: 25%;
-  height: 6.625rem;
+  height: 5.5rem;
   overflow: hidden;
 
   &:not(&:last-of-type):not(:focus) {

--- a/src/components/InformationModals/subcomponents/JoinModal/JoinModal.tsx
+++ b/src/components/InformationModals/subcomponents/JoinModal/JoinModal.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from "react-i18next";
 import {
   ModalParagraph,
   ModalSubTitle,
-  ModalTitle,
+  ScrollableModalContainer,
 } from "../../../../styled-components/Modal/Modal";
 import GuideButton, { GuideButtonProps } from "../GuideButton/GuideButton";
 import { GuideButtons } from "./JoinModal.styles";
@@ -36,8 +36,7 @@ const JoinModal: FC = () => {
   const { t } = useTranslation(["information"]);
 
   return (
-    <>
-      <ModalTitle type="h2">{t("information:join.title")}</ModalTitle>
+    <ScrollableModalContainer>
       <ModalParagraph>{t("information:join.intro")}</ModalParagraph>
 
       <ModalParagraph>{t("information:join.paragraph")}</ModalParagraph>
@@ -60,7 +59,7 @@ const JoinModal: FC = () => {
           );
         })}
       </GuideButtons>
-    </>
+    </ScrollableModalContainer>
   );
 };
 

--- a/src/components/Page/Page.tsx
+++ b/src/components/Page/Page.tsx
@@ -1,8 +1,6 @@
 import { FC, ReactElement, useState } from "react";
 
-import InformationModals, {
-  InformationType,
-} from "../InformationModals/InformationModals";
+import { InformationModalType } from "../InformationModals/InformationModals";
 import SocialButtons from "../SocialButtons/SocialButtons";
 import SwapWidget from "../SwapWidget/SwapWidget";
 import Toaster from "../Toasts/Toaster";
@@ -12,20 +10,16 @@ import { StyledPage, StyledWallet } from "./Page.styles";
 
 const Page: FC = (): ReactElement => {
   const [
-    activeModalPage,
-    setActiveModalPage,
-  ] = useState<InformationType | null>(null);
+    activeInformationModal,
+    setActiveInformationModal,
+  ] = useState<InformationModalType | null>(null);
   const [transactionsTabOpen, setTransactionsTabOpen] = useState<boolean>(
     false
   );
   const [showWalletList, setShowWalletList] = useState<boolean>(false);
 
-  const onToolbarButtonClick = (type: InformationType) => {
-    setActiveModalPage(type);
-  };
-
-  const onCloseModalClick = () => {
-    setActiveModalPage(null);
+  const onToolbarButtonClick = (type: InformationModalType) => {
+    setActiveInformationModal(type);
   };
 
   return (
@@ -40,16 +34,14 @@ const Page: FC = (): ReactElement => {
       <WidgetFrame open={transactionsTabOpen}>
         <SwapWidget
           showWalletList={showWalletList}
+          activeInformationModal={activeInformationModal}
           setShowWalletList={setShowWalletList}
           onTrackTransactionClicked={() => setTransactionsTabOpen(true)}
+          afterInformationModalClose={() => setActiveInformationModal(null)}
           transactionsTabOpen={transactionsTabOpen}
         />
       </WidgetFrame>
       <SocialButtons />
-      <InformationModals
-        onCloseModalClick={onCloseModalClick}
-        activeModal={activeModalPage}
-      />
     </StyledPage>
   );
 };

--- a/src/components/SwapWidget/SwapWidget.tsx
+++ b/src/components/SwapWidget/SwapWidget.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useEffect, useContext, FC } from "react";
+import React, { useState, useMemo, useEffect, useContext, FC } from "react";
 import { useTranslation } from "react-i18next";
 import { useHistory, useRouteMatch } from "react-router-dom";
 
@@ -69,7 +69,9 @@ import findEthOrTokenByAddress from "../../helpers/findEthOrTokenByAddress";
 import { AppRoutes } from "../../routes";
 import type { Error } from "../ErrorList/ErrorList";
 import { ErrorList } from "../ErrorList/ErrorList";
+import { InformationModalType } from "../InformationModals/InformationModals";
 import GasFreeSwapsModal from "../InformationModals/subcomponents/GasFreeSwapsModal/GasFreeSwapsModal";
+import JoinModal from "../InformationModals/subcomponents/JoinModal/JoinModal";
 import ProtocolFeeDiscountModal from "../InformationModals/subcomponents/ProtocolFeeDiscountModal/ProtocolFeeDiscountModal";
 import Overlay from "../Overlay/Overlay";
 import { notifyError } from "../Toasts/ToastController";
@@ -95,15 +97,18 @@ const initialBaseAmount = "";
 type SwapWidgetPropsType = {
   showWalletList: boolean;
   transactionsTabOpen: boolean;
+  activeInformationModal: InformationModalType | null;
   setShowWalletList: (x: boolean) => void;
   onTrackTransactionClicked: () => void;
+  afterInformationModalClose: () => void;
 };
 
 const SwapWidget: FC<SwapWidgetPropsType> = ({
   showWalletList,
-  transactionsTabOpen,
+  activeInformationModal,
   setShowWalletList,
   onTrackTransactionClicked,
+  afterInformationModalClose,
 }) => {
   // Redux
   const dispatch = useAppDispatch();
@@ -812,6 +817,14 @@ const SwapWidget: FC<SwapWidgetPropsType> = ({
         isHidden={!protocolFeeDiscountInfo}
       >
         <ProtocolFeeDiscountModal />
+      </Overlay>
+
+      <Overlay
+        title={t("information:join.title")}
+        onClose={afterInformationModalClose}
+        isHidden={!activeInformationModal}
+      >
+        <JoinModal />
       </Overlay>
     </>
   );

--- a/src/components/Toolbar/Toolbar.tsx
+++ b/src/components/Toolbar/Toolbar.tsx
@@ -1,7 +1,7 @@
 import React, { FC } from "react";
 import { useTranslation } from "react-i18next";
 
-import { InformationType } from "../InformationModals/InformationModals";
+import { InformationModalType } from "../InformationModals/InformationModals";
 import {
   IconAirswap,
   ToolbarButtonsContainer,
@@ -10,7 +10,7 @@ import {
 import ToolbarButton from "./subcomponents/ToolbarButton/ToolbarButton";
 
 export type ToolbarProps = {
-  onButtonClick?: (type: InformationType) => void;
+  onButtonClick?: (type: InformationModalType) => void;
 };
 
 const Toolbar: FC<ToolbarProps> = ({ onButtonClick }) => {
@@ -18,7 +18,7 @@ const Toolbar: FC<ToolbarProps> = ({ onButtonClick }) => {
 
   // TODO: Add content for "about" in modals
 
-  const onToolbarButtonClick = (type: InformationType) => {
+  const onToolbarButtonClick = (type: InformationModalType) => {
     if (onButtonClick) {
       onButtonClick(type);
     }

--- a/src/components/WalletProviderList/WalletProviderList.tsx
+++ b/src/components/WalletProviderList/WalletProviderList.tsx
@@ -1,5 +1,3 @@
-import { useState } from "react";
-
 import { useReducedMotion } from "framer-motion";
 
 import SUPPORTED_WALLET_PROVIDERS, {

--- a/src/styled-components/Modal/Modal.tsx
+++ b/src/styled-components/Modal/Modal.tsx
@@ -1,42 +1,17 @@
 import { DefaultTheme } from "styled-components/macro";
 import styled from "styled-components/macro";
-import Modal from "styled-react-modal";
 
-import IconButton from "../../components/IconButton/IconButton";
 import { InfoSubHeading, Title } from "../../components/Typography/Typography";
-import breakPoints from "../../style/breakpoints";
+import { ScrollBarStyle } from "../../style/mixins";
 import { sizes } from "../../style/sizes";
 
-export const StyledModal = Modal.styled`
-  position: relative;
-  top: 1rem;
-  border: 1px solid ${(props: { theme: DefaultTheme }) =>
-    props.theme.colors.borderGrey};
-  border-radius: 0.1875rem;
-  width: 37.5rem;
-  min-height: 30rem;
-  padding: 2.5rem 2.125rem;
-  background: ${(props: { theme: DefaultTheme }) =>
-    props.theme.colors.darkGrey};
+export const ScrollableModalContainer = styled.div`
+  ${ScrollBarStyle};
 
-  @media ${breakPoints.tabletPortraitUp} {
-    left: calc(${sizes.toolBarWidth}/2);
-  }
-
-  @media ${breakPoints.tabletLandscapeUp} {
-    left: 0;
-  }
-`;
-
-export const ModalCloseButton = styled(IconButton)`
-  position: absolute;
-  top: 1.5rem;
-  right: 1.5rem;
-  padding: 0.25rem;
-`;
-
-export const ModalTitle = styled(Title)`
-  margin-bottom: 1.5rem;
+  padding-right: 1.5rem;
+  padding-bottom: 1.5rem;
+  height: calc(100% - ${sizes.tradeContainerPadding});
+  overflow-y: scroll;
 `;
 
 export const ModalParagraph = styled(InfoSubHeading)`

--- a/yarn.lock
+++ b/yarn.lock
@@ -3893,7 +3893,7 @@
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.1.tgz#20f18294f797f2209b5f65c8e3b5c8e8261d127c"
   integrity sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==
 
-"@types/styled-components@*", "@types/styled-components@^5.1.12":
+"@types/styled-components@^5.1.12":
   version "5.1.15"
   resolved "https://registry.yarnpkg.com/@types/styled-components/-/styled-components-5.1.15.tgz#30855b40aa80b3b4e4c0e43a4af366e7c246d148"
   integrity sha512-4evch8BRI3AKgb0GAZ/sn+mSeB+Dq7meYtMi7J/0Mg98Dt1+r8fySOek7Sjw1W+Wskyjc93565o5xWAT/FdY0Q==
@@ -3901,14 +3901,6 @@
     "@types/hoist-non-react-statics" "*"
     "@types/react" "*"
     csstype "^3.0.2"
-
-"@types/styled-react-modal@^1.2.1":
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/@types/styled-react-modal/-/styled-react-modal-1.2.1.tgz#178a05b482d6fa95d48bc6d2c81ff926f13f76a9"
-  integrity sha512-wEKR3TtryjVGsTeTYvP1cG5fm7KkxssErlDvTqh+YEB565eJnYBPGAutpJK0ejAPNTb/apn1fKsHomU80NXLew==
-  dependencies:
-    "@types/react" "*"
-    "@types/styled-components" "*"
 
 "@types/tapable@^1", "@types/tapable@^1.0.5":
   version "1.0.8"
@@ -15847,13 +15839,6 @@ styled-components@^5.3.1:
     hoist-non-react-statics "^3.0.0"
     shallowequal "^1.1.0"
     supports-color "^5.5.0"
-
-styled-react-modal@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/styled-react-modal/-/styled-react-modal-2.1.0.tgz#524451deb2faba329f3a004d28733b3e6de27744"
-  integrity sha512-GgUzhU4oCCA31OFKv/rCIj0DN4FDVRirGWKH+pGsFyvlr7qxeyAsiM09J0Tss107dJ6EUhK+D7U8JzQuq06hZw==
-  dependencies:
-    prop-types "^15.7.2"
 
 stylehacks@^4.0.0:
   version "4.0.3"


### PR DESCRIPTION
Closes #374 

- Information modals now open in the SwapWidget overlay
- Removed everything regarding styled-react-modal