### PR TITLE
Adding listener for deposit and withdrawals

### DIFF
--- a/src/assets/weth9.abi.json
+++ b/src/assets/weth9.abi.json
@@ -1,0 +1,155 @@
+{
+  "abi": [
+    {
+      "constant": true,
+      "inputs": [],
+      "name": "name",
+      "outputs": [{ "name": "", "type": "string" }],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": false,
+      "inputs": [
+        { "name": "guy", "type": "address" },
+        { "name": "wad", "type": "uint256" }
+      ],
+      "name": "approve",
+      "outputs": [{ "name": "", "type": "bool" }],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [],
+      "name": "totalSupply",
+      "outputs": [{ "name": "", "type": "uint256" }],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": false,
+      "inputs": [
+        { "name": "src", "type": "address" },
+        { "name": "dst", "type": "address" },
+        { "name": "wad", "type": "uint256" }
+      ],
+      "name": "transferFrom",
+      "outputs": [{ "name": "", "type": "bool" }],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "constant": false,
+      "inputs": [{ "name": "wad", "type": "uint256" }],
+      "name": "withdraw",
+      "outputs": [],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [],
+      "name": "decimals",
+      "outputs": [{ "name": "", "type": "uint8" }],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [{ "name": "", "type": "address" }],
+      "name": "balanceOf",
+      "outputs": [{ "name": "", "type": "uint256" }],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [],
+      "name": "symbol",
+      "outputs": [{ "name": "", "type": "string" }],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": false,
+      "inputs": [
+        { "name": "dst", "type": "address" },
+        { "name": "wad", "type": "uint256" }
+      ],
+      "name": "transfer",
+      "outputs": [{ "name": "", "type": "bool" }],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "constant": false,
+      "inputs": [],
+      "name": "deposit",
+      "outputs": [],
+      "payable": true,
+      "stateMutability": "payable",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [
+        { "name": "", "type": "address" },
+        { "name": "", "type": "address" }
+      ],
+      "name": "allowance",
+      "outputs": [{ "name": "", "type": "uint256" }],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    { "payable": true, "stateMutability": "payable", "type": "fallback" },
+    {
+      "anonymous": false,
+      "inputs": [
+        { "indexed": true, "name": "src", "type": "address" },
+        { "indexed": true, "name": "guy", "type": "address" },
+        { "indexed": false, "name": "wad", "type": "uint256" }
+      ],
+      "name": "Approval",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        { "indexed": true, "name": "src", "type": "address" },
+        { "indexed": true, "name": "dst", "type": "address" },
+        { "indexed": false, "name": "wad", "type": "uint256" }
+      ],
+      "name": "Transfer",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        { "indexed": true, "name": "dst", "type": "address" },
+        { "indexed": false, "name": "wad", "type": "uint256" }
+      ],
+      "name": "Deposit",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        { "indexed": true, "name": "src", "type": "address" },
+        { "indexed": false, "name": "wad", "type": "uint256" }
+      ],
+      "name": "Withdrawal",
+      "type": "event"
+    }
+  ]
+}

--- a/src/components/Toasts/ToastController.tsx
+++ b/src/components/Toasts/ToastController.tsx
@@ -6,7 +6,7 @@ import { TokenInfo } from "@airswap/types";
 import {
   SubmittedApproval,
   SubmittedDepositOrder,
-  SubmittedOrder,
+  SubmittedTransactionWithOrder,
   SubmittedWithdrawOrder,
   TransactionType,
 } from "../../features/transactions/transactionsSlice";
@@ -17,7 +17,7 @@ import TransactionToast from "./TransactionToast";
 export const notifyTransaction = (
   type: TransactionType,
   transaction:
-    | SubmittedOrder
+    | SubmittedTransactionWithOrder
     | SubmittedApproval
     | SubmittedDepositOrder
     | SubmittedWithdrawOrder,
@@ -31,7 +31,7 @@ export const notifyTransaction = (
     (type === "Order" || type === "Deposit" || type === "Withdraw") &&
     chainId
   ) {
-    const tx: SubmittedOrder = transaction as SubmittedOrder;
+    const tx: SubmittedTransactionWithOrder = transaction as SubmittedTransactionWithOrder;
     /*  TODO: fix toaster for multiple tabs or apps
         now that we have a listener, you can have multiple
         tabs open that receives the same order event. Only one redux

--- a/src/components/TransactionsTab/subcomponents/WalletTransaction/WalletTransaction.tsx
+++ b/src/components/TransactionsTab/subcomponents/WalletTransaction/WalletTransaction.tsx
@@ -8,7 +8,7 @@ import BigNumber from "bignumber.js";
 
 import {
   SubmittedApproval,
-  SubmittedOrder,
+  SubmittedTransactionWithOrder,
   SubmittedTransaction,
 } from "../../../../features/transactions/transactionsSlice";
 import findEthOrTokenByAddress from "../../../../helpers/findEthOrTokenByAddress";
@@ -86,7 +86,7 @@ const WalletTransaction = ({
       </Container>
     );
   } else {
-    const tx: SubmittedOrder = transaction as SubmittedOrder;
+    const tx: SubmittedTransactionWithOrder = transaction as SubmittedTransactionWithOrder;
     const senderToken = findEthOrTokenByAddress(
       tx.order.senderToken,
       tokens,

--- a/src/constants/Weth9.ts
+++ b/src/constants/Weth9.ts
@@ -1,0 +1,6 @@
+const Weth9: Record<number, string> = {
+  1: "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+  4: "0xc778417e063141139fce010982780140aa0cd5ab",
+};
+
+export default Weth9;

--- a/src/contexts/lastLook/LastLook.tsx
+++ b/src/contexts/lastLook/LastLook.tsx
@@ -17,7 +17,7 @@ import { LAST_LOOK_ORDER_EXPIRY_SEC } from "../../constants/configParams";
 import { updatePricing } from "../../features/pricing/pricingSlice";
 import { TradeTerms } from "../../features/tradeTerms/tradeTermsSlice";
 import {
-  SubmittedOrder,
+  SubmittedTransactionWithOrder,
   submitTransactionWithExpiry,
 } from "../../features/transactions/transactionsSlice";
 
@@ -168,7 +168,7 @@ const LastLookProvider: FC = ({ children }) => {
         ...signature,
       };
 
-      const transaction: SubmittedOrder = {
+      const transaction: SubmittedTransactionWithOrder = {
         type: "Order",
         order: order,
         nonce: order.nonce,

--- a/src/features/balances/balancesSlice.ts
+++ b/src/features/balances/balancesSlice.ts
@@ -229,7 +229,7 @@ export const {
 } = balancesSlice.actions;
 export const {
   incrementBy: incrementAllowanceLightBy,
-  decrementBy: decreementAllowanceLightBy,
+  decrementBy: decrementAllowanceLightBy,
   set: setAllowanceLight,
 } = allowancesLightSlice.actions;
 export const {

--- a/src/features/transactions/swapEventSubscriber.ts
+++ b/src/features/transactions/swapEventSubscriber.ts
@@ -9,7 +9,7 @@ import { mineTransaction } from "./transactionActions";
 import {
   LastLookTransaction,
   ProtocolType,
-  SubmittedOrder,
+  SubmittedTransactionWithOrder,
   SubmittedTransaction,
   TransactionsState,
 } from "./transactionsSlice";
@@ -99,9 +99,9 @@ export const mapSwapEvent = (
   // swap. (Someone else includes "us" in another browser).
   if (!transaction && signerWallet.toLowerCase() === account.toLowerCase()) {
     transaction = transactions.all.find(
-      (t: SubmittedTransaction | SubmittedOrder) =>
+      (t: SubmittedTransaction | SubmittedTransactionWithOrder) =>
         t.nonce === nonce &&
-        (t as SubmittedOrder).order?.signerWallet.toLowerCase() ===
+        (t as SubmittedTransactionWithOrder).order?.signerWallet.toLowerCase() ===
           signerWallet.toLowerCase()
     ) as LastLookTransaction;
   }

--- a/src/features/transactions/transactionsSlice.ts
+++ b/src/features/transactions/transactionsSlice.ts
@@ -43,13 +43,13 @@ export interface SubmittedTransaction {
   protocol?: ProtocolType;
 }
 
-export interface SubmittedOrder extends SubmittedTransaction {
+export interface SubmittedTransactionWithOrder extends SubmittedTransaction {
   order: LightOrder;
 }
 
-export interface SubmittedRFQOrder extends SubmittedOrder {}
+export interface SubmittedRFQOrder extends SubmittedTransactionWithOrder {}
 
-export interface SubmittedLastLookOrder extends SubmittedOrder {}
+export interface SubmittedLastLookOrder extends SubmittedTransactionWithOrder {}
 
 export interface LastLookTransaction
   extends SubmittedTransaction,

--- a/src/features/transactions/wrapEventSubscriber.ts
+++ b/src/features/transactions/wrapEventSubscriber.ts
@@ -8,14 +8,15 @@ import {
   decrementBalanceBy,
   incrementBalanceBy,
 } from "../balances/balancesSlice";
-import { SubmittedTransaction } from "./transactionsSlice";
+import { SubmittedTransactionWithOrder } from "./transactionsSlice";
 
 const handleWrapEvent = (data: any, dispatch: any) => {
   const transactions = store.getState().transactions;
 
-  const transaction: SubmittedTransaction | null =
-    transactions.all.find((t: any) => t.hash === data[2].transactionHash) ||
-    null;
+  const transaction: SubmittedTransactionWithOrder | null =
+    (transactions.all.find(
+      (t: any) => t.hash === data[2].transactionHash
+    ) as SubmittedTransactionWithOrder) || null;
 
   // If we don't have a 'transaction', we don't already know about this swap
   // and therefore don't need to update the UI.
@@ -23,17 +24,13 @@ const handleWrapEvent = (data: any, dispatch: any) => {
 
   dispatch(
     decrementBalanceBy({
-      //@ts-ignore
       tokenAddress: transaction.order.senderToken,
-      //@ts-ignore
       amount: transaction.order.senderAmount,
     })
   );
   dispatch(
     incrementBalanceBy({
-      //@ts-ignore
       tokenAddress: transaction.order.signerToken,
-      //@ts-ignore
       amount: transaction.order.senderAmount,
     })
   );

--- a/src/features/transactions/wrapEventSubscriber.ts
+++ b/src/features/transactions/wrapEventSubscriber.ts
@@ -10,10 +10,10 @@ import {
 } from "../balances/balancesSlice";
 import { SubmittedTransaction } from "./transactionsSlice";
 
-const handleWrapEvent = (eventName: string, data: any, dispatch: any) => {
+const handleWrapEvent = (data: any, dispatch: any) => {
   const transactions = store.getState().transactions;
 
-  let transaction: SubmittedTransaction | null =
+  const transaction: SubmittedTransaction | null =
     transactions.all.find((t: any) => t.hash === data[2].transactionHash) ||
     null;
 
@@ -46,9 +46,9 @@ export default function subscribeToWrapEvents(params: {
 }) {
   const { wrapContract, dispatch } = params;
   wrapContract.on("Deposit", async (...data) =>
-    handleWrapEvent("Deposit", data, dispatch)
+    handleWrapEvent(data, dispatch)
   );
   wrapContract.on("Withdrawal", async (...data) =>
-    handleWrapEvent("Withdrawal", data, dispatch)
+    handleWrapEvent(data, dispatch)
   );
 }

--- a/src/features/transactions/wrapEventSubscriber.ts
+++ b/src/features/transactions/wrapEventSubscriber.ts
@@ -1,0 +1,53 @@
+import { Dispatch } from "@reduxjs/toolkit";
+
+import { Contract } from "ethers";
+
+import { store } from "../../app/store";
+import {
+  decrementBalanceBy,
+  incrementBalanceBy,
+} from "../balances/balancesSlice";
+import { SubmittedTransaction } from "./transactionsSlice";
+
+const handleWrapEvent = (eventName: string, data: any, dispatch: any) => {
+  const transactions = store.getState().transactions;
+
+  let transaction: SubmittedTransaction | null =
+    transactions.all.find((t: any) => t.hash === data[2].transactionHash) ||
+    null;
+
+  // If we don't have a 'transaction', we don't already know about this swap
+  // and therefore don't need to update the UI.
+  if (!transaction) return;
+
+  dispatch(
+    decrementBalanceBy({
+      //@ts-ignore
+      tokenAddress: transaction.order.senderToken,
+      //@ts-ignore
+      amount: transaction.order.senderAmount,
+    })
+  );
+  dispatch(
+    incrementBalanceBy({
+      //@ts-ignore
+      tokenAddress: transaction.order.signerToken,
+      //@ts-ignore
+      amount: transaction.order.senderAmount,
+    })
+  );
+};
+
+export default function subscribeToWrapEvents(params: {
+  wrapContract: Contract;
+  library: any;
+  dispatch: Dispatch;
+}) {
+  const { wrapContract, dispatch } = params;
+  wrapContract.on("Deposit", async (...data) =>
+    handleWrapEvent("Deposit", data, dispatch)
+  );
+  wrapContract.on("Withdrawal", async (...data) =>
+    handleWrapEvent("Withdrawal", data, dispatch)
+  );
+}

--- a/src/features/transactions/wrapEventSubscriber.ts
+++ b/src/features/transactions/wrapEventSubscriber.ts
@@ -1,3 +1,4 @@
+import { Web3Provider } from "@ethersproject/providers";
 import { Dispatch } from "@reduxjs/toolkit";
 
 import { Contract } from "ethers";
@@ -40,7 +41,7 @@ const handleWrapEvent = (eventName: string, data: any, dispatch: any) => {
 
 export default function subscribeToWrapEvents(params: {
   wrapContract: Contract;
-  library: any;
+  library: Web3Provider;
   dispatch: Dispatch;
 }) {
   const { wrapContract, dispatch } = params;

--- a/src/features/wallet/Wallet.tsx
+++ b/src/features/wallet/Wallet.tsx
@@ -16,6 +16,7 @@ import * as Weth9Contract from "../../assets/weth9.abi.json";
 import SettingsButton from "../../components/SettingsButton/SettingsButton";
 import TransactionsTab from "../../components/TransactionsTab/TransactionsTab";
 import WalletButton from "../../components/WalletButton/WalletButton";
+import Weth9Deploys from "../../constants/Weth9";
 import {
   AbstractConnector,
   WalletProvider,
@@ -67,11 +68,6 @@ type WalletPropsType = {
   setTransactionsTabOpen: (x: boolean) => void;
 };
 
-const wrapDeploys: { [key: number]: string } = {
-  1: "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
-  4: "0xc778417e063141139fce010982780140aa0cd5ab",
-};
-
 export const Wallet: FC<WalletPropsType> = ({
   setShowWalletList,
   transactionsTabOpen,
@@ -121,14 +117,12 @@ export const Wallet: FC<WalletPropsType> = ({
       subscribeToSwapEvents({
         account: account!,
         lightContract,
-        //@ts-ignore
         library,
         chainId,
         dispatch,
       });
       subscribeToWrapEvents({
         wrapContract,
-        //@ts-ignore
         library,
         dispatch,
       });
@@ -153,7 +147,7 @@ export const Wallet: FC<WalletPropsType> = ({
       );
       setLightContract(lightContract);
       const wrapContract = new Contract(
-        wrapDeploys[chainId],
+        Weth9Deploys[chainId],
         Weth9Contract.abi,
         //@ts-ignore
         library


### PR DESCRIPTION
Add listeners for Deposit and Withdrawal events from WETH contract to catch ETH/WETH "swaps"

Events are emitted on` ETH->WETH` and `WETH<-ETH` (and only these are the ones I've tested).

Closes #379 