### PR TITLE
Fixed small wallet transaction animation bug

### DIFF
--- a/src/components/TransactionsTab/subcomponents/AnimatedWalletTransaction/AnimatedWalletTransaction.tsx
+++ b/src/components/TransactionsTab/subcomponents/AnimatedWalletTransaction/AnimatedWalletTransaction.tsx
@@ -70,9 +70,7 @@ const AnimatedWalletTransaction = ({
     >
       <WalletTransaction
         animate={{ borderColor: theme.colors.borderGrey }}
-        initial={
-          !transactionTooOld && { borderColor: theme.colors.white }
-        }
+        initial={!transactionTooOld && { borderColor: theme.colors.white }}
         transition={{
           delay: heightAnimationDuration,
           duration: borderAnimationDuration,

--- a/src/components/TransactionsTab/subcomponents/AnimatedWalletTransaction/AnimatedWalletTransaction.tsx
+++ b/src/components/TransactionsTab/subcomponents/AnimatedWalletTransaction/AnimatedWalletTransaction.tsx
@@ -57,7 +57,7 @@ const AnimatedWalletTransaction = ({
   return (
     <Container
       animate={{ height: walletTransactionHeight }}
-      initial={!transactionIsOlderThanHalfHour && { height: "0rem" }}
+      initial={!transactionTooOld && { height: "0rem" }}
       exit={{
         height: "0rem",
         transition: {
@@ -71,7 +71,7 @@ const AnimatedWalletTransaction = ({
       <WalletTransaction
         animate={{ borderColor: theme.colors.borderGrey }}
         initial={
-          !transactionIsOlderThanHalfHour && { borderColor: theme.colors.white }
+          !transactionTooOld && { borderColor: theme.colors.white }
         }
         transition={{
           delay: heightAnimationDuration,

--- a/src/components/TransactionsTab/subcomponents/AnimatedWalletTransaction/AnimatedWalletTransaction.tsx
+++ b/src/components/TransactionsTab/subcomponents/AnimatedWalletTransaction/AnimatedWalletTransaction.tsx
@@ -37,7 +37,14 @@ const AnimatedWalletTransaction = ({
 
   const themeHasChanged = useMemo(() => isMounted, [theme.name]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  const heightAnimationDuration = shouldReduceMotion ? 0 : 0.3;
+  // Prevents all older (half hour) transactions animating simultaneously when user changes wallet
+  const transactionTooOld = useMemo(
+    () => (new Date().getTime() - transaction.timestamp) / 1000 > 1800,
+    [transaction]
+  );
+
+  const heightAnimationDuration =
+    shouldReduceMotion || transactionTooOld ? 0 : 0.3;
 
   // Border transition doesn't clear after animation ends, so when changing theme
   // the border color animates, which looks weird.
@@ -50,7 +57,7 @@ const AnimatedWalletTransaction = ({
   return (
     <Container
       animate={{ height: walletTransactionHeight }}
-      initial={{ height: "0rem" }}
+      initial={!transactionIsOlderThanHalfHour && { height: "0rem" }}
       exit={{
         height: "0rem",
         transition: {
@@ -63,7 +70,9 @@ const AnimatedWalletTransaction = ({
     >
       <WalletTransaction
         animate={{ borderColor: theme.colors.borderGrey }}
-        initial={{ borderColor: theme.colors.white }}
+        initial={
+          !transactionIsOlderThanHalfHour && { borderColor: theme.colors.white }
+        }
         transition={{
           delay: heightAnimationDuration,
           duration: borderAnimationDuration,


### PR DESCRIPTION
Fixes #455 

Only recent transactions (within half an hour) animate in with this fix:

https://user-images.githubusercontent.com/86911296/147755972-cec25702-4fb6-4d27-abec-cb67836bcad9.mov


