### PR TITLE
added new static sitemap

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,12 +1,14 @@
-<?xml version="1.0" encoding="UTF-8" ?>
-<urlset
-  xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
-  xmlns:news="http://www.google.com/schemas/sitemap-news/0.9"
-  xmlns:xhtml="http://www.w3.org/1999/xhtml"
-  xmlns:mobile="http://www.google.com/schemas/sitemap-mobile/1.0"
-  xmlns:image="http://www.google.com/schemas/sitemap-image/1.1"
-  xmlns:video="http://www.google.com/schemas/sitemap-video/1.1"
->
-    <url> <loc>https://www.airswap.io/</loc> <changefreq
-    >daily</changefreq> <priority>0.7</priority> </url>
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+<url>
+    <loc>https://www.airswap.io</loc>
+    <lastmod>2022-02-09</lastmod>
+    <changefreq>monthly</changefreq>
+</url>
+
+<url>
+    <loc>https://www.airswap.io/#/whitepaper</loc>
+    <lastmod>2022-02-09</lastmod>
+    <changefreq>yearly</changefreq>
+</url>
 </urlset>


### PR DESCRIPTION
In relation to issue 465 - sitemaps.

We only have 2 static urls that we would want a search engine to index. With this in mind, a simple approach might be best?

I added a new XML sitemap to /sitemap.xml. The only thing I don't like it that the lastmod field is not dynamic. Do we want to think about how we do that or are we happy with the static values as is?

