### PR TITLE
Feature/185 multi language seo

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
     "react-icons": "^4.2.0",
     "react-redux": "^7.2.4",
     "react-router-dom": "^5.2.0",
-    "react-router-last-location": "^2.0.1",
     "react-scripts": "4.0.3",
     "string_decoder": "^1.3.0",
     "styled-components": "^5.3.1",

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -37,10 +37,9 @@
     "language": "LANGUAGE",
     "theme": "THEME",
     "stats": "stats",
-    "otc": "OTC",
     "vote": "vote",
     "build": "build",
-    "about": "about",
+    "learn": "learn",
     "join": "join",
     "reloadPage": "Reload Page",
     "settings": "Settings",
@@ -135,15 +134,14 @@
     "invalid_sig": "Invalid signature",
     "expiry_passed": "Order has expired",
     "unauthorized": "Signer has not authorized the signatory",
-    "signer_allowance_low": "Signer has not approved the signer amount",
-    "signer_balance_low": "Signer does not have enough balance",
+    "signer_allowance_low": "Signer does not have enough balance",
+    "signer_balance_low": "Signer has not approved the signer amount",
     "nonce_aleady_used": "Nonce has been already used or cancelled",
     "unableSwap": "Unable to swap",
     "swapFail": "The swap would fail for the following reasons."
   },
   "wallet": {
     "connectWallet": "Connect Wallet",
-    "copyAddress": "Copy Address",
     "notConnected": "Not connected",
     "unsupportedNetwork": "Unsupported network",
     "unsupported": "Unsupported",
@@ -169,7 +167,12 @@
     "completedTransactions": "Completed transactions",
     "noCompletedTransactions": "No completed transactions",
     "transactionLink": "Transaction link",
-    "get": "Get",
-    "viewOnExplorer": "View on explorer"
+    "copyAddress": "Copy address",
+    "viewOnExplorer": "View on explorer",
+    "get": "Get"
+  },
+  "app": {
+    "title": "AirSwap: Peer-to-peer Token Trading DEX and Open Source Developer DAO",
+    "description": "AirSwap powers peer-to-peer trading."
   }
 }

--- a/public/locales/zh/translation.json
+++ b/public/locales/zh/translation.json
@@ -39,7 +39,7 @@
     "stats": "統計",
     "vote": "投票",
     "build": "建設",
-    "about": "學習",
+    "learn": "學習",
     "join": "加入",
     "reloadPage": "請重新輸入網頁",
     "settings": "選項",
@@ -142,7 +142,6 @@
   },
   "wallet": {
     "connectWallet": "連接錢包",
-    "copyAddress": "複製地址",
     "notConnected": "未連接",
     "unsupportedNetwork": "未支持網路",
     "unsupported": "未支持",
@@ -168,7 +167,12 @@
     "completedTransactions": "已完成的交易",
     "noCompletedTransactions": "無完成的交易",
     "transactionLink": "交易連結",
-    "get":"下載",
-    "viewOnExplorer": "在以太坊資源瀏覽器上查看"
+    "copyAddress": "複製地址",
+    "viewOnExplorer": "在以太坊資源瀏覽器上查看",
+    "get": "下載"
+  },
+  "app": {
+    "title": "AirSwap: P2P交易代幣的去中心化交易所和由程式開發DAO",
+    "description": ""
   }
 }

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -9,8 +9,14 @@
 >
     <url>
         <loc>https://www.airswap.io/</loc>
-        <changefreq>daily</changefreq>
-        <priority>0.7</priority>
+        <xhtml:link rel="alternate" hreflang="en" href="https://www.airswap.io/en/" />
+        <xhtml:link rel="alternate" hreflang="nb" href="https://www.airswap.io/nb/" />
+        <xhtml:link rel="alternate" hreflang="nl" href="https://www.airswap.io/nl/" />
+        <xhtml:link rel="alternate" hreflang="pt" href="https://www.airswap.io/pt/" />
+        <xhtml:link rel="alternate" hreflang="fr" href="https://www.airswap.io/fr/" />
+        <xhtml:link rel="alternate" hreflang="zh-tr" href="https://www.airswap.io/zh-tr/" />
+        <changefreq>weekly</changefreq>
+        <priority>1</priority>
     </url>
     <url>
         <loc>https://www.airswap.io/whitepaper/</loc>
@@ -18,6 +24,12 @@
     </url>
     <url>
         <loc>https://www.airswap.io/join/</loc>
+        <xhtml:link rel="alternate" hreflang="en" href="https://www.airswap.io/en/join/" />
+        <xhtml:link rel="alternate" hreflang="nb" href="https://www.airswap.io/nb/join/" />
+        <xhtml:link rel="alternate" hreflang="nl" href="https://www.airswap.io/nl/join/" />
+        <xhtml:link rel="alternate" hreflang="pt" href="https://www.airswap.io/pt/join/" />
+        <xhtml:link rel="alternate" hreflang="fr" href="https://www.airswap.io/fr/join/" />
+        <xhtml:link rel="alternate" hreflang="zh-tr" href="https://www.airswap.io/zh-tr/join/" />
         <changefreq>monthly</changefreq>
     </url>
 </urlset>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,7 +19,6 @@ const App = (): JSX.Element => {
         title={
           "AirSwap: Peer-to-peer Token Trading DEX and Open Source Developer DAO"
         }
-        description={"AirSwap powers peer-to-peer trading."}
       />
 
       <Router>

--- a/src/components/HelmetContainer/HelmetContainer.tsx
+++ b/src/components/HelmetContainer/HelmetContainer.tsx
@@ -3,7 +3,7 @@ import { Helmet } from "react-helmet";
 
 type HelmetContainerProps = {
   title: string;
-  description: string;
+  description?: string;
 };
 
 const HelmetContainer: FC<HelmetContainerProps> = ({
@@ -14,11 +14,11 @@ const HelmetContainer: FC<HelmetContainerProps> = ({
   return (
     <Helmet>
       <title>{title}</title>
-      <meta name="description" content={description} />
+      {description && <meta name="description" content={description} />}
       <meta property="og:title" content={title} />
-      <meta property="og:description" content={description} />
+      {description && <meta property="og:description" content={description} />}
       <meta name="twitter:title" content={title} />
-      <meta name="twitter:description" content={description} />
+      {description && <meta name="twitter:description" content={description} />}
       {children}
     </Helmet>
   );

--- a/src/components/HelmetContainer/HelmetContainer.tsx
+++ b/src/components/HelmetContainer/HelmetContainer.tsx
@@ -8,17 +8,17 @@ type HelmetContainerProps = {
 
 const HelmetContainer: FC<HelmetContainerProps> = ({
   title,
-  description,
+  description = "",
   children,
 }) => {
   return (
     <Helmet>
       <title>{title}</title>
-      {description && <meta name="description" content={description} />}
+      <meta name="description" content={description} />
       <meta property="og:title" content={title} />
-      {description && <meta property="og:description" content={description} />}
+      <meta property="og:description" content={description} />
       <meta name="twitter:title" content={title} />
-      {description && <meta name="twitter:description" content={description} />}
+      <meta name="twitter:description" content={description} />
       {children}
     </Helmet>
   );

--- a/src/components/Page/Page.tsx
+++ b/src/components/Page/Page.tsx
@@ -1,5 +1,5 @@
 import { FC, ReactElement, useEffect, useState } from "react";
-import { useHistory, useLocation } from "react-router-dom";
+import { useHistory } from "react-router-dom";
 import { useLastLocation } from "react-router-last-location";
 
 import { Web3Provider } from "@ethersproject/providers";
@@ -8,6 +8,7 @@ import { useWeb3React } from "@web3-react/core";
 import { useAppDispatch } from "../../app/hooks";
 import { resetOrders } from "../../features/orders/ordersSlice";
 import { Wallet } from "../../features/wallet/Wallet";
+import useAppRouteParams from "../../hooks/useAppRouteParams";
 import { AppRoutes } from "../../routes";
 import { InformationModalType } from "../InformationModals/InformationModals";
 import SwapWidget from "../SwapWidget/SwapWidget";
@@ -16,11 +17,11 @@ import Toolbar from "../Toolbar/Toolbar";
 import WidgetFrame from "../WidgetFrame/WidgetFrame";
 import { InnerContainer, StyledPage, StyledSocialButtons } from "./Page.styles";
 
-function getInformationModalFromLocation(
-  location: string
+function getInformationModalFromRoute(
+  route: AppRoutes | undefined
 ): InformationModalType | undefined {
-  switch (location) {
-    case `/${AppRoutes.join}`:
+  switch (route) {
+    case AppRoutes.join:
       return AppRoutes.join;
     default:
       return undefined;
@@ -30,19 +31,21 @@ function getInformationModalFromLocation(
 const Page: FC = (): ReactElement => {
   const dispatch = useAppDispatch();
   const history = useHistory();
-  const location = useLocation().pathname;
   const lastLocation = useLastLocation();
   const { active: web3ProviderIsActive } = useWeb3React<Web3Provider>();
 
+  const appRouteParams = useAppRouteParams();
   const [activeInformationModal, setActiveInformationModal] = useState<
     InformationModalType | undefined
-  >(getInformationModalFromLocation(location));
+  >(getInformationModalFromRoute(appRouteParams.route));
   const [transactionsTabOpen, setTransactionsTabOpen] = useState(false);
   const [showWalletList, setShowWalletList] = useState(false);
   const [showMobileToolbar, setShowMobileToolbar] = useState(false);
 
   const handleLinkButtonClick = (type: InformationModalType) => {
-    history.push(`/${type}`);
+    history.push(
+      appRouteParams.langInRoute ? `${appRouteParams.lang}/${type}` : `/${type}`
+    );
   };
 
   const handleCloseMobileToolbarButtonClick = () => {
@@ -79,10 +82,10 @@ const Page: FC = (): ReactElement => {
   }, [showMobileToolbar]);
 
   useEffect(() => {
-    setActiveInformationModal(getInformationModalFromLocation(location));
-  }, [location]);
-
-  useEffect(() => {}, [location]);
+    setActiveInformationModal(
+      getInformationModalFromRoute(appRouteParams.route)
+    );
+  }, [appRouteParams.route]);
 
   return (
     <StyledPage>

--- a/src/components/Page/Page.tsx
+++ b/src/components/Page/Page.tsx
@@ -1,4 +1,5 @@
-import { FC, ReactElement, useEffect, useState } from "react";
+import React, { FC, ReactElement, useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
 import { useHistory } from "react-router-dom";
 
 import { Web3Provider } from "@ethersproject/providers";
@@ -9,6 +10,7 @@ import { resetOrders } from "../../features/orders/ordersSlice";
 import { Wallet } from "../../features/wallet/Wallet";
 import useAppRouteParams from "../../hooks/useAppRouteParams";
 import { AppRoutes } from "../../routes";
+import HelmetContainer from "../HelmetContainer/HelmetContainer";
 import { InformationModalType } from "../InformationModals/InformationModals";
 import SwapWidget from "../SwapWidget/SwapWidget";
 import Toaster from "../Toasts/Toaster";
@@ -30,6 +32,7 @@ function getInformationModalFromRoute(
 const Page: FC = (): ReactElement => {
   const dispatch = useAppDispatch();
   const history = useHistory();
+  const { t } = useTranslation();
   const { active: web3ProviderIsActive } = useWeb3React<Web3Provider>();
 
   const appRouteParams = useAppRouteParams();
@@ -87,6 +90,7 @@ const Page: FC = (): ReactElement => {
 
   return (
     <StyledPage>
+      <HelmetContainer title={t("app.title")} />
       <InnerContainer>
         <Toaster open={transactionsTabOpen} />
         <Toolbar

--- a/src/components/Page/Page.tsx
+++ b/src/components/Page/Page.tsx
@@ -1,6 +1,5 @@
 import { FC, ReactElement, useEffect, useState } from "react";
 import { useHistory } from "react-router-dom";
-import { useLastLocation } from "react-router-last-location";
 
 import { Web3Provider } from "@ethersproject/providers";
 import { useWeb3React } from "@web3-react/core";
@@ -31,7 +30,6 @@ function getInformationModalFromRoute(
 const Page: FC = (): ReactElement => {
   const dispatch = useAppDispatch();
   const history = useHistory();
-  const lastLocation = useLastLocation();
   const { active: web3ProviderIsActive } = useWeb3React<Web3Provider>();
 
   const appRouteParams = useAppRouteParams();
@@ -42,10 +40,22 @@ const Page: FC = (): ReactElement => {
   const [showWalletList, setShowWalletList] = useState(false);
   const [showMobileToolbar, setShowMobileToolbar] = useState(false);
 
-  const handleLinkButtonClick = (type: InformationModalType) => {
-    history.push(
-      appRouteParams.langInRoute ? `${appRouteParams.lang}/${type}` : `/${type}`
-    );
+  const reset = () => {
+    setActiveInformationModal(undefined);
+    setShowMobileToolbar(false);
+    dispatch(resetOrders());
+  };
+
+  const handleLinkButtonClick = () => {
+    history.push(appRouteParams.justifiedBaseUrl);
+  };
+
+  const handleAirswapButtonClick = () => {
+    history.push(appRouteParams.justifiedBaseUrl);
+  };
+
+  const handleInformationModalCloseButtonClick = () => {
+    history.push(appRouteParams.justifiedBaseUrl);
   };
 
   const handleCloseMobileToolbarButtonClick = () => {
@@ -54,23 +64,6 @@ const Page: FC = (): ReactElement => {
 
   const handleOpenMobileToolbarButtonClick = () => {
     setShowMobileToolbar(true);
-  };
-
-  const handleAirswapButtonClick = () => {
-    history.push("");
-    setActiveInformationModal(undefined);
-    setShowMobileToolbar(false);
-    dispatch(resetOrders());
-  };
-
-  const handleInformationModalCloseButtonClick = () => {
-    // Check if user has a route before modal. If not then we can't use history.goBack
-    // because the user would route away from the website
-    if (lastLocation) {
-      history.goBack();
-    } else {
-      history.push("");
-    }
   };
 
   useEffect(() => {
@@ -85,6 +78,11 @@ const Page: FC = (): ReactElement => {
     setActiveInformationModal(
       getInformationModalFromRoute(appRouteParams.route)
     );
+
+    if (appRouteParams.route === undefined) {
+      reset();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [appRouteParams.route]);
 
   return (

--- a/src/components/SettingsPopover/SettingsPopover.styles.tsx
+++ b/src/components/SettingsPopover/SettingsPopover.styles.tsx
@@ -1,3 +1,5 @@
+import { Link } from "react-router-dom";
+
 import styled from "styled-components/macro";
 
 import breakPoints from "../../style/breakpoints";
@@ -46,7 +48,7 @@ export const ThemeContainer = styled.div`
 `;
 
 type ButtonStyleProps = {
-  active: boolean;
+  $isActive: boolean;
 };
 
 export const ThemeButton = styled.button<ButtonStyleProps>`
@@ -54,15 +56,15 @@ export const ThemeButton = styled.button<ButtonStyleProps>`
 
   line-height: 1.5;
   font-size: 0.875rem;
-  font-weight: ${(props) => (props.active ? "600" : "400")};
+  font-weight: ${(props) => (props.$isActive ? "600" : "400")};
   color: ${(props) =>
-    props.active
+    props.$isActive
       ? props.theme.name === "dark"
         ? props.theme.colors.white
         : props.theme.colors.primary
       : props.theme.colors.darkSubText};
   background-color: ${(props) =>
-    props.active ? props.theme.colors.borderGrey : "transparent"};
+    props.$isActive ? props.theme.colors.borderGrey : "transparent"};
 `;
 
 type LocaleContainerType = {
@@ -83,7 +85,7 @@ export const LocaleContainer = styled.div<LocaleContainerType>`
   }
 `;
 
-export const LocaleButton = styled.button<ButtonStyleProps>`
+export const LocaleButton = styled(Link)<ButtonStyleProps>`
   ${BorderlessButtonStyle};
 
   display: flex;
@@ -93,16 +95,16 @@ export const LocaleButton = styled.button<ButtonStyleProps>`
   text-align: left;
   padding: 0.5rem 0 0.5rem 1rem;
   border-radius: 1px;
-  font-weight: ${(props) => (props.active ? "600" : "400")};
+  font-weight: ${(props) => (props.$isActive ? "600" : "400")};
   font-size: 0.875rem;
   color: ${(props) =>
-    props.active
+    props.$isActive
       ? props.theme.name === "dark"
         ? props.theme.colors.white
         : props.theme.colors.primary
       : props.theme.colors.darkSubText};
   background-color: ${(props) =>
-    props.active ? props.theme.colors.borderGrey : "transparent"};
+    props.$isActive ? props.theme.colors.borderGrey : "transparent"};
 
   &:hover,
   &:focus {

--- a/src/components/SettingsPopover/SettingsPopover.tsx
+++ b/src/components/SettingsPopover/SettingsPopover.tsx
@@ -4,16 +4,13 @@ import { useTranslation } from "react-i18next";
 import { ThemeType } from "styled-components/macro";
 
 import { useAppDispatch, useAppSelector } from "../../app/hooks";
-import {
-  SUPPORTED_LOCALES,
-  LOCALE_LABEL,
-  DEFAULT_LOCALE,
-} from "../../constants/locales";
+import { SUPPORTED_LOCALES, LOCALE_LABEL } from "../../constants/locales";
 import {
   selectTheme,
   setTheme,
 } from "../../features/userSettings/userSettingsSlice";
 import useWindowSize from "../../helpers/useWindowSize";
+import useAppRouteParams from "../../hooks/useAppRouteParams";
 import {
   Container,
   ThemeContainer,
@@ -34,15 +31,9 @@ const SettingsPopover = ({ open, popoverRef }: SettingsPopoverPropsType) => {
   const selectedTheme = useAppSelector(selectTheme);
   const [overflow, setOverflow] = useState<boolean>(false);
 
-  // selects i18nextLang first, window language, falls back to default locale (en)
-  // TODO: keep track of different langauage locale (e.g. en-US, en-AU)?
-  const [selectedLocale, setSelectedLocale] = useState<string>(
-    localStorage.getItem("i18nextLng")?.substring(0, 2) ||
-      window.navigator.language.substring(0, 2) ||
-      DEFAULT_LOCALE
-  );
+  const appRouteParams = useAppRouteParams();
   const dispatch = useAppDispatch();
-  const { t, i18n } = useTranslation();
+  const { t } = useTranslation();
 
   const handleThemeButtonClick = (newTheme: ThemeType | "system") => {
     dispatch(setTheme(newTheme));
@@ -60,19 +51,19 @@ const SettingsPopover = ({ open, popoverRef }: SettingsPopoverPropsType) => {
       <PopoverSection title={t("common.theme")}>
         <ThemeContainer>
           <ThemeButton
-            active={selectedTheme === "system"}
+            $isActive={selectedTheme === "system"}
             onClick={() => handleThemeButtonClick("system")}
           >
             {t("common.system")}
           </ThemeButton>
           <ThemeButton
-            active={selectedTheme === "light"}
+            $isActive={selectedTheme === "light"}
             onClick={() => handleThemeButtonClick("light")}
           >
             {t("common.light")}
           </ThemeButton>
           <ThemeButton
-            active={selectedTheme === "dark"}
+            $isActive={selectedTheme === "dark"}
             onClick={() => handleThemeButtonClick("dark")}
           >
             {t("common.dark")}
@@ -85,11 +76,8 @@ const SettingsPopover = ({ open, popoverRef }: SettingsPopoverPropsType) => {
             return (
               <LocaleButton
                 key={locale}
-                active={selectedLocale === locale}
-                onClick={() => {
-                  setSelectedLocale(locale);
-                  i18n.changeLanguage(locale);
-                }}
+                $isActive={appRouteParams.lang === locale}
+                to={`/${locale}${appRouteParams.urlWithoutLang}`}
               >
                 {LOCALE_LABEL[locale]}
               </LocaleButton>

--- a/src/components/SwapWidget/SwapWidget.tsx
+++ b/src/components/SwapWidget/SwapWidget.tsx
@@ -326,20 +326,22 @@ const SwapWidget: FC<SwapWidgetPropsType> = ({
   };
 
   const handleSetToken = (type: TokenSelectModalTypes, value: string) => {
+    const baseRoute = `${appRouteParams.justifiedBaseUrl}/${AppRoutes.swap}`;
+
     if (type === "base") {
       value === quoteToken
-        ? history.push({ pathname: `/${AppRoutes.swap}/${value}/${baseToken}` })
+        ? history.push({ pathname: `${baseRoute}/${value}/${baseToken}` })
         : history.push({
-            pathname: `/${AppRoutes.swap}/${value}/${quoteToken}`,
+            pathname: `${baseRoute}/${value}/${quoteToken}`,
           });
       setBaseAmount("");
     } else {
       value === baseToken
         ? history.push({
-            pathname: `/${AppRoutes.swap}/${quoteToken}/${value}`,
+            pathname: `${baseRoute}/${quoteToken}/${value}`,
           })
         : history.push({
-            pathname: `/${AppRoutes.swap}/${baseToken}/${value}`,
+            pathname: `${baseRoute}/${baseToken}/${value}`,
           });
     }
   };

--- a/src/components/SwapWidget/SwapWidget.tsx
+++ b/src/components/SwapWidget/SwapWidget.tsx
@@ -61,6 +61,10 @@ import {
   ProtocolType,
   selectPendingApprovals,
 } from "../../features/transactions/transactionsSlice";
+import {
+  setUserTokens,
+  selectUserTokens,
+} from "../../features/userSettings/userSettingsSlice";
 import { setActiveProvider } from "../../features/wallet/walletSlice";
 import { Validator } from "../../helpers/Validator";
 import findEthOrTokenByAddress from "../../helpers/findEthOrTokenByAddress";
@@ -83,13 +87,14 @@ import StyledSwapWidget, {
   InfoContainer,
   StyledWalletProviderList,
 } from "./SwapWidget.styles";
+import getTokenPairs from "./helpers/getTokenPairs";
 import ActionButtons, {
   ButtonActions,
 } from "./subcomponents/ActionButtons/ActionButtons";
 import SwapInputs from "./subcomponents/SwapInputs/SwapInputs";
 import SwapWidgetHeader from "./subcomponents/SwapWidgetHeader/SwapWidgetHeader";
 
-type TokenSelectModalTypes = "base" | "quote" | null;
+export type TokenSelectModalTypes = "base" | "quote" | null;
 type SwapType = "swap" | "swapWithWrap" | "wrapOrUnwrap";
 
 const initialBaseAmount = "";
@@ -124,6 +129,7 @@ const SwapWidget: FC<SwapWidgetPropsType> = ({
   const supportedTokens = useAppSelector(selectAllSupportedTokens);
   const pendingApprovals = useAppSelector(selectPendingApprovals);
   const tradeTerms = useAppSelector(selectTradeTerms);
+  const userTokens = useAppSelector(selectUserTokens);
 
   // Contexts
   const LastLook = useContext(LastLookContext);
@@ -176,24 +182,24 @@ const SwapWidget: FC<SwapWidgetPropsType> = ({
     error: web3Error,
   } = useWeb3React<Web3Provider>();
 
-  let defaultBaseTokenAddress: string | null = allTokens.length
+  const defaultBaseTokenAddress: string | null = allTokens.length
     ? findTokensBySymbol("USDT", allTokens)[0].address
     : null;
-  let defaultQuoteTokenAddress: string | null = allTokens.length
+  const defaultQuoteTokenAddress: string | null = allTokens.length
     ? findTokensBySymbol("WETH", allTokens)[0].address
     : null;
 
-  // Use default tokens only if neither are specified in the URL.
+  // Use default tokens only if neither are specified in the URL or store.
   const baseToken = tokenFrom
     ? tokenFrom
     : tokenTo
     ? null
-    : defaultBaseTokenAddress;
+    : userTokens.tokenFrom || defaultBaseTokenAddress;
   const quoteToken = tokenTo
     ? tokenTo
     : tokenFrom
     ? null
-    : defaultQuoteTokenAddress;
+    : userTokens.tokenTo || defaultQuoteTokenAddress;
 
   const baseTokenInfo = useMemo(
     () =>
@@ -327,23 +333,24 @@ const SwapWidget: FC<SwapWidgetPropsType> = ({
 
   const handleSetToken = (type: TokenSelectModalTypes, value: string) => {
     const baseRoute = `${appRouteParams.justifiedBaseUrl}/${AppRoutes.swap}`;
+    const { tokenFrom, tokenTo } = getTokenPairs(
+      type,
+      value,
+      quoteToken,
+      baseToken
+    );
 
     if (type === "base") {
-      value === quoteToken
-        ? history.push({ pathname: `${baseRoute}/${value}/${baseToken}` })
-        : history.push({
-            pathname: `${baseRoute}/${value}/${quoteToken}`,
-          });
       setBaseAmount("");
-    } else {
-      value === baseToken
-        ? history.push({
-            pathname: `${baseRoute}/${quoteToken}/${value}`,
-          })
-        : history.push({
-            pathname: `${baseRoute}/${baseToken}/${value}`,
-          });
     }
+
+    if (tokenFrom && tokenTo) {
+      dispatch(setUserTokens({ tokenFrom, tokenTo }));
+    }
+
+    history.push({
+      pathname: `${baseRoute}/${tokenFrom}/${tokenTo}`,
+    });
   };
 
   let insufficientBalance: boolean = false;

--- a/src/components/SwapWidget/SwapWidget.tsx
+++ b/src/components/SwapWidget/SwapWidget.tsx
@@ -1,6 +1,6 @@
 import React, { FC, useContext, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { useHistory, useRouteMatch } from "react-router-dom";
+import { useHistory } from "react-router-dom";
 
 import { wethAddresses } from "@airswap/constants";
 import { Registry, Wrapper } from "@airswap/libraries";
@@ -64,8 +64,9 @@ import {
 import { setActiveProvider } from "../../features/wallet/walletSlice";
 import { Validator } from "../../helpers/Validator";
 import findEthOrTokenByAddress from "../../helpers/findEthOrTokenByAddress";
+import useAppRouteParams from "../../hooks/useAppRouteParams";
 import useReferencePriceSubscriber from "../../hooks/useReferencePriceSubscriber";
-import { AppRoutes, SwapRoutes } from "../../routes";
+import { AppRoutes } from "../../routes";
 import type { Error } from "../ErrorList/ErrorList";
 import { ErrorList } from "../ErrorList/ErrorList";
 import { InformationModalType } from "../InformationModals/InformationModals";
@@ -128,9 +129,7 @@ const SwapWidget: FC<SwapWidgetPropsType> = ({
   const LastLook = useContext(LastLookContext);
 
   // Input states
-  const match = useRouteMatch<{ tokenFrom?: string; tokenTo?: string }>(
-    `/${AppRoutes.swap}/:${SwapRoutes.tokenFrom}/:${SwapRoutes.tokenTo}`
-  );
+  const appRouteParams = useAppRouteParams();
   const [tokenFrom, setTokenFrom] = useState<string | undefined>();
   const [tokenTo, setTokenTo] = useState<string | undefined>();
   const [baseAmount, setBaseAmount] = useState(initialBaseAmount);
@@ -246,11 +245,9 @@ const SwapWidget: FC<SwapWidgetPropsType> = ({
   ]);
 
   useEffect(() => {
-    if (match && match.params) {
-      setTokenFrom(match.params.tokenFrom);
-      setTokenTo(match.params.tokenTo);
-    }
-  }, [match]);
+    setTokenFrom(appRouteParams.tokenFrom);
+    setTokenTo(appRouteParams.tokenTo);
+  }, [appRouteParams]);
 
   useEffect(() => {
     if (ordersStatus === "reset") {

--- a/src/components/SwapWidget/helpers/getTokenPairs.ts
+++ b/src/components/SwapWidget/helpers/getTokenPairs.ts
@@ -1,0 +1,18 @@
+import { TokenSelectModalTypes } from "../SwapWidget";
+
+export default function getTokenPairs(
+  type: TokenSelectModalTypes,
+  value: string,
+  quoteToken: string | null,
+  baseToken: string | null
+): { tokenFrom: string | null; tokenTo: string | null } {
+  if (type === "base") {
+    return value === quoteToken
+      ? { tokenFrom: value, tokenTo: baseToken }
+      : { tokenFrom: value, tokenTo: quoteToken };
+  } else {
+    return value === baseToken
+      ? { tokenFrom: quoteToken, tokenTo: value }
+      : { tokenFrom: baseToken, tokenTo: value };
+  }
+}

--- a/src/components/Toolbar/Toolbar.styles.tsx
+++ b/src/components/Toolbar/Toolbar.styles.tsx
@@ -67,6 +67,7 @@ export const ToolbarButtonsContainer = styled.div<{ $overflow?: boolean }>`
   margin: 0;
   width: ${({ $overflow }) => ($overflow ? "calc(100% - 1rem)" : "100%")};
   padding-right: ${({ $overflow }) => ($overflow ? "1rem" : "0")};
+  overflow-x: hidden;
   overflow-y: ${({ $overflow }) => ($overflow ? "scroll" : "hidden")};
 
   @media (min-height: ${sizes.toolbarMaxHeight}) and (${breakPoints.tabletPortraitUp}) {

--- a/src/components/Toolbar/Toolbar.tsx
+++ b/src/components/Toolbar/Toolbar.tsx
@@ -88,7 +88,7 @@ const Toolbar: FC<ToolbarProps> = ({
       <ToolbarButtonsContainer ref={scrollContainerRef} $overflow={overflow}>
         <ToolbarButton
           iconName="swap-horizontal"
-          text={t("common.otc")}
+          text="OTC"
           href="https://trader.airswap.io/"
         />
         <ToolbarButton
@@ -108,7 +108,7 @@ const Toolbar: FC<ToolbarProps> = ({
         />
         <ToolbarButton
           iconName="learn"
-          text={t("common.about")}
+          text={t("common.learn")}
           href="https://about.airswap.io/"
         />
         <ToolbarButton

--- a/src/components/Toolbar/subcomponents/ToolbarButton/ToolbarButton.styles.tsx
+++ b/src/components/Toolbar/subcomponents/ToolbarButton/ToolbarButton.styles.tsx
@@ -81,9 +81,14 @@ export const ToolBarLinkContainer = styled(Link)`
 
 export const Text = styled.div`
   margin-left: 0.75rem;
+  width: 100%;
   font-weight: 600;
   font-size: ${() => (isActiveLanguageLogographic() ? "0.75rem" : "0.675rem")};
   text-transform: uppercase;
+  text-align: center;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 
   @media (min-height: ${sizes.toolbarMaxHeight}) {
     font-size: ${() =>

--- a/src/components/Toolbar/subcomponents/ToolbarButton/ToolbarButton.tsx
+++ b/src/components/Toolbar/subcomponents/ToolbarButton/ToolbarButton.tsx
@@ -1,5 +1,6 @@
 import React, { FC } from "react";
 
+import useAppRouteParams from "../../../../hooks/useAppRouteParams";
 import { AppRoutes } from "../../../../routes";
 import Icon from "../../../Icon/Icon";
 import {
@@ -26,6 +27,8 @@ const ToolbarButton: FC<ToolbarButtonProps> = ({
   link,
   onClick,
 }) => {
+  const appRouteParams = useAppRouteParams();
+
   const renderInner = () => {
     return (
       <>
@@ -36,8 +39,12 @@ const ToolbarButton: FC<ToolbarButtonProps> = ({
   };
 
   if (link) {
+    const url = appRouteParams.langInRoute
+      ? `/${appRouteParams.lang}/${link}`
+      : `/${link}`;
+
     return (
-      <ToolBarLinkContainer onClick={onClick} to={`/${link}`}>
+      <ToolBarLinkContainer onClick={onClick} to={url}>
         {renderInner()}
       </ToolBarLinkContainer>
     );

--- a/src/components/Toolbar/subcomponents/ToolbarButton/ToolbarButton.tsx
+++ b/src/components/Toolbar/subcomponents/ToolbarButton/ToolbarButton.tsx
@@ -39,9 +39,7 @@ const ToolbarButton: FC<ToolbarButtonProps> = ({
   };
 
   if (link) {
-    const url = appRouteParams.langInRoute
-      ? `/${appRouteParams.lang}/${link}`
-      : `/${link}`;
+    const url = `${appRouteParams.justifiedBaseUrl}/${link}`;
 
     return (
       <ToolBarLinkContainer onClick={onClick} to={url}>

--- a/src/components/Toolbar/subcomponents/ToolbarButton/ToolbarButton.tsx
+++ b/src/components/Toolbar/subcomponents/ToolbarButton/ToolbarButton.tsx
@@ -39,10 +39,11 @@ const ToolbarButton: FC<ToolbarButtonProps> = ({
   };
 
   if (link) {
-    const url = `${appRouteParams.justifiedBaseUrl}/${link}`;
-
     return (
-      <ToolBarLinkContainer onClick={onClick} to={url}>
+      <ToolBarLinkContainer
+        onClick={onClick}
+        to={`${appRouteParams.justifiedBaseUrl}/${link}`}
+      >
         {renderInner()}
       </ToolBarLinkContainer>
     );

--- a/src/constants/locales.ts
+++ b/src/constants/locales.ts
@@ -6,7 +6,7 @@ export const SUPPORTED_LOCALES = [
   "nl",
   "pt",
   "zh-tr",
-];
+] as const;
 
 export type SupportedLocale = typeof SUPPORTED_LOCALES[number];
 
@@ -19,4 +19,27 @@ export const LOCALE_LABEL: { [locale in SupportedLocale]: string } = {
   pt: "Portugues",
   fr: "Français",
   "zh-tr": "中文繁體",
+};
+
+export const getUserLanguage = (): SupportedLocale => {
+  const localStorageLanguage = localStorage
+    .getItem("i18nextLng")
+    ?.substring(0, 2) as SupportedLocale;
+  const deviceLanguage = window.navigator.language.substring(
+    0,
+    2
+  ) as SupportedLocale;
+
+  if (
+    localStorageLanguage &&
+    SUPPORTED_LOCALES.includes(localStorageLanguage)
+  ) {
+    return localStorageLanguage;
+  }
+
+  if (deviceLanguage && SUPPORTED_LOCALES.includes(deviceLanguage)) {
+    return deviceLanguage;
+  }
+
+  return DEFAULT_LOCALE;
 };

--- a/src/features/userSettings/userSettingsSlice.ts
+++ b/src/features/userSettings/userSettingsSlice.ts
@@ -1,4 +1,4 @@
-import { createSlice } from "@reduxjs/toolkit";
+import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 
 import { ThemeType } from "styled-components/macro";
 
@@ -6,12 +6,20 @@ import { RootState } from "../../app/store";
 
 export interface UserSettingsState {
   theme: ThemeType | "system";
+  tokens: {
+    tokenFrom?: string;
+    tokenTo?: string;
+  };
 }
 
 export const THEME_LOCAL_STORAGE_KEY = "airswap/theme";
 
 const initialState: UserSettingsState = {
   theme: localStorage[THEME_LOCAL_STORAGE_KEY] || "dark",
+  tokens: {
+    tokenFrom: undefined,
+    tokenTo: undefined,
+  },
 };
 
 const userSettingsSlice = createSlice({
@@ -22,11 +30,19 @@ const userSettingsSlice = createSlice({
       localStorage[THEME_LOCAL_STORAGE_KEY] = payload;
       state.theme = payload;
     },
+    setUserTokens: (
+      state,
+      action: PayloadAction<{ tokenFrom: string; tokenTo: string }>
+    ) => {
+      state.tokens = action.payload;
+    },
   },
 });
 
 export const selectTheme = (state: RootState) => state.userSettings.theme;
 
-export const { setTheme } = userSettingsSlice.actions;
+export const selectUserTokens = (state: RootState) => state.userSettings.tokens;
+
+export const { setTheme, setUserTokens } = userSettingsSlice.actions;
 
 export default userSettingsSlice.reducer;

--- a/src/hooks/useAppRouteParams.ts
+++ b/src/hooks/useAppRouteParams.ts
@@ -1,14 +1,16 @@
 import { useRouteMatch } from "react-router-dom";
 
+import { useAppSelector } from "../app/hooks";
 import {
   DEFAULT_LOCALE,
   getUserLanguage,
   SUPPORTED_LOCALES,
   SupportedLocale,
 } from "../constants/locales";
+import { selectUserTokens } from "../features/userSettings/userSettingsSlice";
 import { AppRoutes, SwapRoutes } from "../routes";
 
-interface AppRouteParams {
+export interface AppRouteParams {
   lang: SupportedLocale;
   route?: AppRoutes;
   tokenFrom?: string;
@@ -31,6 +33,7 @@ function transformStringToSupportedLanguage(
 
 const useAppRouteParams = (): AppRouteParams => {
   const routeMatch = useRouteMatch<{ routeOrLang?: string }>(`/:routeOrLang`);
+  const userTokens = useAppSelector(selectUserTokens);
 
   const routeWithLangMatch = useRouteMatch<{
     lang: SupportedLocale;
@@ -55,10 +58,12 @@ const useAppRouteParams = (): AppRouteParams => {
       transformStringToSupportedLanguage(swapWithLangMatch.params.lang) ||
       DEFAULT_LOCALE;
 
+    const { tokenFrom, tokenTo } = swapWithLangMatch.params;
+
     return {
       lang,
-      tokenFrom: swapWithLangMatch.params.tokenFrom,
-      tokenTo: swapWithLangMatch.params.tokenTo,
+      tokenFrom,
+      tokenTo,
       route: AppRoutes.swap,
       url: swapWithLangMatch.url,
       urlWithoutLang: `/${AppRoutes.swap}/${swapWithLangMatch.params.tokenFrom}/${swapWithLangMatch.params.tokenTo}/`,
@@ -67,9 +72,11 @@ const useAppRouteParams = (): AppRouteParams => {
   }
 
   if (swapMatch) {
+    const { tokenFrom, tokenTo } = swapMatch.params;
+
     return {
-      tokenFrom: swapMatch.params.tokenFrom,
-      tokenTo: swapMatch.params.tokenTo,
+      tokenFrom,
+      tokenTo,
       route: swapMatch.params.route,
       lang: getUserLanguage(),
       url: swapMatch.url,
@@ -85,6 +92,8 @@ const useAppRouteParams = (): AppRouteParams => {
 
     return {
       lang,
+      tokenFrom: userTokens?.tokenFrom,
+      tokenTo: userTokens?.tokenTo,
       route: routeWithLangMatch.params.route,
       url: routeWithLangMatch.url,
       urlWithoutLang: `/${routeWithLangMatch.params.route}`,
@@ -97,6 +106,8 @@ const useAppRouteParams = (): AppRouteParams => {
     const lang = transformStringToSupportedLanguage(routeOrLang as string);
 
     return {
+      tokenFrom: userTokens?.tokenFrom,
+      tokenTo: userTokens?.tokenTo,
       route: lang ? undefined : (routeMatch.params.routeOrLang as AppRoutes),
       lang: lang || DEFAULT_LOCALE,
       url: routeMatch.url,
@@ -106,10 +117,12 @@ const useAppRouteParams = (): AppRouteParams => {
   }
 
   return {
+    tokenFrom: userTokens?.tokenFrom,
+    tokenTo: userTokens?.tokenTo,
     lang: getUserLanguage(),
-    url: "/",
-    urlWithoutLang: "/",
-    justifiedBaseUrl: "/",
+    url: "",
+    urlWithoutLang: "",
+    justifiedBaseUrl: "",
   };
 };
 

--- a/src/hooks/useAppRouteParams.ts
+++ b/src/hooks/useAppRouteParams.ts
@@ -1,0 +1,112 @@
+import { useRouteMatch } from "react-router-dom";
+
+import {
+  DEFAULT_LOCALE,
+  getUserLanguage,
+  SUPPORTED_LOCALES,
+  SupportedLocale,
+} from "../constants/locales";
+import { AppRoutes, SwapRoutes } from "../routes";
+
+interface AppRouteParams {
+  lang: SupportedLocale;
+  route?: AppRoutes;
+  tokenFrom?: string;
+  tokenTo?: string;
+  url: string;
+  urlWithoutLang: string;
+  langInRoute: boolean;
+}
+
+function transformStringToSupportedLanguage(
+  value: string
+): SupportedLocale | undefined {
+  const locale = value as SupportedLocale;
+  if (SUPPORTED_LOCALES.includes(locale)) {
+    return locale;
+  }
+
+  return undefined;
+}
+
+const useAppRouteParams = (): AppRouteParams => {
+  const routeMatch = useRouteMatch<{ routeOrLang?: string }>(`/:routeOrLang`);
+
+  const routeWithLangMatch = useRouteMatch<{
+    lang: SupportedLocale;
+    route?: AppRoutes;
+  }>(`/:lang/:route`);
+
+  const swapMatch = useRouteMatch<{
+    route?: AppRoutes.swap;
+    tokenFrom?: string;
+    tokenTo?: string;
+  }>(`/:route/:${SwapRoutes.tokenFrom}/:${SwapRoutes.tokenTo}`);
+
+  const swapWithLangMatch = useRouteMatch<{
+    lang: SupportedLocale;
+    route?: AppRoutes.swap;
+    tokenFrom?: string;
+    tokenTo?: string;
+  }>(`/:lang/:route/:${SwapRoutes.tokenFrom}/:${SwapRoutes.tokenTo}`);
+
+  if (swapWithLangMatch) {
+    return {
+      tokenFrom: swapWithLangMatch.params.tokenFrom,
+      tokenTo: swapWithLangMatch.params.tokenTo,
+      route: swapWithLangMatch.params.route,
+      lang:
+        transformStringToSupportedLanguage(swapWithLangMatch.params.lang) ||
+        DEFAULT_LOCALE,
+      url: swapWithLangMatch.url,
+      urlWithoutLang: `/${swapWithLangMatch.params.route}/${swapWithLangMatch.params.tokenFrom}/${swapWithLangMatch.params.tokenTo}`,
+      langInRoute: true,
+    };
+  }
+
+  if (swapMatch) {
+    return {
+      tokenFrom: swapMatch.params.tokenFrom,
+      tokenTo: swapMatch.params.tokenTo,
+      route: swapMatch.params.route,
+      lang: getUserLanguage(),
+      url: swapMatch.url,
+      urlWithoutLang: swapMatch.url,
+      langInRoute: false,
+    };
+  }
+
+  if (routeWithLangMatch) {
+    return {
+      route: routeWithLangMatch.params.route,
+      lang:
+        transformStringToSupportedLanguage(routeWithLangMatch.params.lang) ||
+        DEFAULT_LOCALE,
+      url: routeWithLangMatch.url,
+      urlWithoutLang: `/${routeWithLangMatch.params.route}`,
+      langInRoute: true,
+    };
+  }
+
+  if (routeMatch) {
+    const { routeOrLang } = routeMatch.params;
+    const lang = transformStringToSupportedLanguage(routeOrLang as string);
+
+    return {
+      route: lang ? undefined : (routeMatch.params.routeOrLang as AppRoutes),
+      lang: lang || DEFAULT_LOCALE,
+      url: routeMatch.url,
+      urlWithoutLang: lang ? "/" : routeMatch.url,
+      langInRoute: !!lang,
+    };
+  }
+
+  return {
+    lang: getUserLanguage(),
+    url: "/",
+    urlWithoutLang: "/",
+    langInRoute: false,
+  };
+};
+
+export default useAppRouteParams;

--- a/src/hooks/useAppRouteParams.ts
+++ b/src/hooks/useAppRouteParams.ts
@@ -15,7 +15,7 @@ interface AppRouteParams {
   tokenTo?: string;
   url: string;
   urlWithoutLang: string;
-  langInRoute: boolean;
+  justifiedBaseUrl: string;
 }
 
 function transformStringToSupportedLanguage(
@@ -51,16 +51,18 @@ const useAppRouteParams = (): AppRouteParams => {
   }>(`/:lang/:route/:${SwapRoutes.tokenFrom}/:${SwapRoutes.tokenTo}`);
 
   if (swapWithLangMatch) {
+    const lang =
+      transformStringToSupportedLanguage(swapWithLangMatch.params.lang) ||
+      DEFAULT_LOCALE;
+
     return {
+      lang,
       tokenFrom: swapWithLangMatch.params.tokenFrom,
       tokenTo: swapWithLangMatch.params.tokenTo,
-      route: swapWithLangMatch.params.route,
-      lang:
-        transformStringToSupportedLanguage(swapWithLangMatch.params.lang) ||
-        DEFAULT_LOCALE,
+      route: AppRoutes.swap,
       url: swapWithLangMatch.url,
-      urlWithoutLang: `/${swapWithLangMatch.params.route}/${swapWithLangMatch.params.tokenFrom}/${swapWithLangMatch.params.tokenTo}`,
-      langInRoute: true,
+      urlWithoutLang: `/${AppRoutes.swap}/${swapWithLangMatch.params.tokenFrom}/${swapWithLangMatch.params.tokenTo}/`,
+      justifiedBaseUrl: `/${lang}`,
     };
   }
 
@@ -72,19 +74,21 @@ const useAppRouteParams = (): AppRouteParams => {
       lang: getUserLanguage(),
       url: swapMatch.url,
       urlWithoutLang: swapMatch.url,
-      langInRoute: false,
+      justifiedBaseUrl: `/`,
     };
   }
 
   if (routeWithLangMatch) {
+    const lang =
+      transformStringToSupportedLanguage(routeWithLangMatch.params.lang) ||
+      DEFAULT_LOCALE;
+
     return {
+      lang,
       route: routeWithLangMatch.params.route,
-      lang:
-        transformStringToSupportedLanguage(routeWithLangMatch.params.lang) ||
-        DEFAULT_LOCALE,
       url: routeWithLangMatch.url,
       urlWithoutLang: `/${routeWithLangMatch.params.route}`,
-      langInRoute: true,
+      justifiedBaseUrl: `/${lang}`,
     };
   }
 
@@ -97,7 +101,7 @@ const useAppRouteParams = (): AppRouteParams => {
       lang: lang || DEFAULT_LOCALE,
       url: routeMatch.url,
       urlWithoutLang: lang ? "/" : routeMatch.url,
-      langInRoute: !!lang,
+      justifiedBaseUrl: lang ? `/${lang}` : "/",
     };
   }
 
@@ -105,7 +109,7 @@ const useAppRouteParams = (): AppRouteParams => {
     lang: getUserLanguage(),
     url: "/",
     urlWithoutLang: "/",
-    langInRoute: false,
+    justifiedBaseUrl: "/",
   };
 };
 

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -1,5 +1,4 @@
 import React, { Suspense, useEffect } from "react";
-import { LastLocationProvider } from "react-router-last-location";
 
 import { Web3Provider } from "@ethersproject/providers";
 import { Web3ReactProvider } from "@web3-react/core";
@@ -45,9 +44,7 @@ const Home = (): JSX.Element => {
         {/* Suspense needed here for loading i18n resources */}
         <Suspense fallback={<PageLoader />}>
           <LastLookProvider>
-            <LastLocationProvider>
-              <Page />
-            </LastLocationProvider>
+            <Page />
           </LastLookProvider>
         </Suspense>
       </Web3ReactProvider>

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -1,9 +1,10 @@
-import React, { Suspense } from "react";
+import React, { Suspense, useEffect } from "react";
 import { LastLocationProvider } from "react-router-last-location";
 
 import { Web3Provider } from "@ethersproject/providers";
 import { Web3ReactProvider } from "@web3-react/core";
 
+import i18n from "i18next";
 import { ThemeProvider, ThemeType } from "styled-components/macro";
 
 import { useAppSelector } from "../../app/hooks";
@@ -11,6 +12,7 @@ import Page from "../../components/Page/Page";
 import PageLoader from "../../components/PageLoader/PageLoader";
 import LastLookProvider from "../../contexts/lastLook/LastLook";
 import { selectTheme } from "../../features/userSettings/userSettingsSlice";
+import useAppRouteParams from "../../hooks/useAppRouteParams";
 import useSystemTheme from "../../hooks/useSystemTheme";
 import GlobalStyle from "../../style/GlobalStyle";
 import { darkTheme, lightTheme } from "../../style/themes";
@@ -28,6 +30,12 @@ function getLibrary(provider: any): Web3Provider {
 const Home = (): JSX.Element => {
   const theme = useAppSelector(selectTheme);
   const systemTheme = useSystemTheme();
+  const appRouteParams = useAppRouteParams();
+
+  useEffect(() => {
+    i18n.changeLanguage(appRouteParams.lang);
+  }, [appRouteParams.lang]);
+
   const renderedTheme: ThemeType =
     theme === "system" ? systemTheme : (theme as ThemeType);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -14253,11 +14253,6 @@ react-router-dom@^5.2.0:
     tiny-invariant "^1.0.2"
     tiny-warning "^1.0.0"
 
-react-router-last-location@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/react-router-last-location/-/react-router-last-location-2.0.1.tgz#54d625876dd1448594fa1114aa02e7e21db12970"
-  integrity sha512-3FbFIWwUr2qN28vN9DNdFp6RhUH/yif6ILVff1zT+hLdyGmlNPh3GuPhveb7bHQLgB744QW8L0qtWjX58ESuZQ==
-
 react-router@5.2.1:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/react-router/-/react-router-5.2.1.tgz#4d2e4e9d5ae9425091845b8dbc6d9d276239774d"


### PR DESCRIPTION
- The app now supports the following routes:
https://www.airswap.io/join
https://www.airswap.io/swap/:fromToken/:toToken
https://www.airswap.io/:language
https://www.airswap.io/:language/join
https://www.airswap.io/:language/swap/:fromToken/:toToken

- Updated sitemaps.xml. Hopefully google will pick this up.
- Language buttons are now links
- Fixed ToolbarButton styling when text is too long
- Translations for head title and description (forgot this, will add this asap)

Things we can do after this is make links for all most used trading pairs, like searching for "swap eth to dai", will take you to https://www.airswap.io/swap/eth/dai. But searching in Portuguese will take you to https://www.airswap.io/pt/swap/eth/dai
