### PR TITLE
506: Replace 0x000..000 with native token in url

### DIFF
--- a/src/components/SwapWidget/SwapWidget.tsx
+++ b/src/components/SwapWidget/SwapWidget.tsx
@@ -367,7 +367,9 @@ const SwapWidget: FC<SwapWidgetPropsType> = ({
       dispatch(setUserTokens({ tokenFrom, tokenTo }));
     }
     history.push({
-      pathname: `${baseRoute}/${tokenFromAlias}/${tokenToAlias}`,
+      pathname: `${baseRoute}/${tokenFromAlias || tokenFrom}/${
+        tokenToAlias || tokenTo
+      }`,
     });
   };
 

--- a/src/components/SwapWidget/SwapWidget.tsx
+++ b/src/components/SwapWidget/SwapWidget.tsx
@@ -15,6 +15,10 @@ import { formatUnits } from "ethers/lib/utils";
 
 import { useAppDispatch, useAppSelector } from "../../app/hooks";
 import {
+  transformAddressToAddressAlias,
+  transformAddressAliasToAddress,
+} from "../../constants/addressAliases";
+import {
   ADDITIONAL_QUOTE_BUFFER,
   RECEIVE_QUOTE_TIMEOUT_MS,
 } from "../../constants/configParams";
@@ -349,12 +353,11 @@ const SwapWidget: FC<SwapWidgetPropsType> = ({
 
   const handleSetToken = (type: TokenSelectModalTypes, value: string) => {
     const baseRoute = `${appRouteParams.justifiedBaseUrl}/${AppRoutes.swap}`;
-    const { tokenFrom, tokenTo } = getTokenPairs(
-      type,
-      value,
-      quoteToken,
-      baseToken
-    );
+    const tokenPairs = getTokenPairs(type, value, quoteToken, baseToken);
+    const tokenFrom = transformAddressAliasToAddress(tokenPairs.tokenFrom!);
+    const tokenTo = transformAddressAliasToAddress(tokenPairs.tokenTo!);
+    const tokenFromAlias = transformAddressToAddressAlias(tokenFrom);
+    const tokenToAlias = transformAddressToAddressAlias(tokenTo);
 
     if (type === "base") {
       setBaseAmount("");
@@ -364,7 +367,7 @@ const SwapWidget: FC<SwapWidgetPropsType> = ({
       dispatch(setUserTokens({ tokenFrom, tokenTo }));
     }
     history.push({
-      pathname: `${baseRoute}/${tokenFrom}/${tokenTo}`,
+      pathname: `${baseRoute}/${tokenFromAlias}/${tokenToAlias}`,
     });
   };
 

--- a/src/constants/addressAliases.ts
+++ b/src/constants/addressAliases.ts
@@ -15,7 +15,7 @@ export function transformAddressToAddressAlias(
     return nativeAddressAlias;
   }
 
-  return address;
+  return undefined;
 }
 
 export function transformAddressAliasToAddress(

--- a/src/constants/addressAliases.ts
+++ b/src/constants/addressAliases.ts
@@ -1,0 +1,33 @@
+// Right now we only use an alias for the native address, but we could expand this
+// to multiple addresses depending on chain.
+
+const nativeAddress = "0x0000000000000000000000000000000000000000";
+const nativeAddressAlias = "native";
+
+export function transformAddressToAddressAlias(
+  address?: string
+): string | undefined {
+  if (!address) {
+    return undefined;
+  }
+
+  if (address === nativeAddress) {
+    return nativeAddressAlias;
+  }
+
+  return address;
+}
+
+export function transformAddressAliasToAddress(
+  address?: string
+): string | undefined {
+  if (!address) {
+    return undefined;
+  }
+
+  if (address === nativeAddressAlias) {
+    return nativeAddress;
+  }
+
+  return address;
+}

--- a/src/constants/addressAliases.ts
+++ b/src/constants/addressAliases.ts
@@ -2,6 +2,8 @@
 // to multiple addresses.
 import nativeCurrency from "./nativeCurrency";
 
+const nativeAddressAlias = "native";
+
 export function transformAddressToAddressAlias(
   address?: string,
   chainId: number = 1
@@ -11,7 +13,7 @@ export function transformAddressToAddressAlias(
   }
 
   if (address === nativeCurrency[chainId].address) {
-    return nativeCurrency[chainId].symbol.toLowerCase();
+    return nativeAddressAlias;
   }
 
   return undefined;
@@ -25,7 +27,7 @@ export function transformAddressAliasToAddress(
     return undefined;
   }
 
-  if (address === nativeCurrency[chainId].symbol.toLowerCase()) {
+  if (address === nativeAddressAlias) {
     return nativeCurrency[chainId].address;
   }
 

--- a/src/constants/addressAliases.ts
+++ b/src/constants/addressAliases.ts
@@ -1,32 +1,32 @@
 // Right now we only use an alias for the native address, but we could expand this
-// to multiple addresses depending on chain.
-
-const nativeAddress = "0x0000000000000000000000000000000000000000";
-const nativeAddressAlias = "native";
+// to multiple addresses.
+import nativeCurrency from "./nativeCurrency";
 
 export function transformAddressToAddressAlias(
-  address?: string
+  address?: string,
+  chainId: number = 1
 ): string | undefined {
   if (!address) {
     return undefined;
   }
 
-  if (address === nativeAddress) {
-    return nativeAddressAlias;
+  if (address === nativeCurrency[chainId].address) {
+    return nativeCurrency[chainId].symbol.toLowerCase();
   }
 
   return undefined;
 }
 
 export function transformAddressAliasToAddress(
-  address?: string
+  address?: string,
+  chainId: number = 1
 ): string | undefined {
   if (!address) {
     return undefined;
   }
 
-  if (address === nativeAddressAlias) {
-    return nativeAddress;
+  if (address === nativeCurrency[chainId].symbol.toLowerCase()) {
+    return nativeCurrency[chainId].address;
   }
 
   return address;

--- a/src/hooks/useAppRouteParams.ts
+++ b/src/hooks/useAppRouteParams.ts
@@ -90,7 +90,9 @@ const useAppRouteParams = (): AppRouteParams => {
         tokenToAlias,
         route: AppRoutes.swap,
         url: swapWithLangMatch.url,
-        urlWithoutLang: `/${AppRoutes.swap}/${tokenFromAlias}/${tokenToAlias}/`,
+        urlWithoutLang: `/${AppRoutes.swap}/${tokenFromAlias || tokenFrom}/${
+          tokenToAlias || tokenTo
+        }/`,
         justifiedBaseUrl: `/${lang}`,
       };
     }
@@ -108,12 +110,14 @@ const useAppRouteParams = (): AppRouteParams => {
       return {
         tokenFrom,
         tokenTo,
-        readableTokenFrom: tokenFromAlias,
-        readableTokenTo: tokenToAlias,
+        tokenFromAlias: tokenFromAlias,
+        tokenToAlias: tokenToAlias,
         route: swapMatch.params.route,
         lang: userLanguage,
         url: swapMatch.url,
-        urlWithoutLang: `/${AppRoutes.swap}/${tokenFromAlias}/${tokenToAlias}/`,
+        urlWithoutLang: `/${AppRoutes.swap}/${tokenFromAlias || tokenFrom}/${
+          tokenToAlias || tokenTo
+        }/`,
         justifiedBaseUrl: "",
       };
     }

--- a/src/hooks/useAppRouteParams.ts
+++ b/src/hooks/useAppRouteParams.ts
@@ -1,6 +1,9 @@
 import { useMemo } from "react";
 import { useRouteMatch } from "react-router-dom";
 
+import { Web3Provider } from "@ethersproject/providers";
+import { useWeb3React } from "@web3-react/core";
+
 import {
   transformAddressToAddressAlias,
   transformAddressAliasToAddress,
@@ -47,6 +50,7 @@ function transformStringToSupportedLanguage(
 
 const useAppRouteParams = (): AppRouteParams => {
   const routeMatch = useRouteMatch<{ routeOrLang?: string }>(`/:routeOrLang`);
+  const { chainId } = useWeb3React<Web3Provider>();
 
   const routeWithLangMatch = useRouteMatch<{
     lang: SupportedLocale;
@@ -74,13 +78,15 @@ const useAppRouteParams = (): AppRouteParams => {
         transformStringToSupportedLanguage(swapWithLangMatch.params.lang) ||
         DEFAULT_LOCALE;
       const tokenFrom = transformAddressAliasToAddress(
-        swapWithLangMatch.params.tokenFrom
+        swapWithLangMatch.params.tokenFrom,
+        chainId
       );
       const tokenTo = transformAddressAliasToAddress(
-        swapWithLangMatch.params.tokenTo
+        swapWithLangMatch.params.tokenTo,
+        chainId
       );
-      const tokenFromAlias = transformAddressToAddressAlias(tokenFrom);
-      const tokenToAlias = transformAddressToAddressAlias(tokenTo);
+      const tokenFromAlias = transformAddressToAddressAlias(tokenFrom, chainId);
+      const tokenToAlias = transformAddressToAddressAlias(tokenTo, chainId);
 
       return {
         lang,
@@ -96,16 +102,20 @@ const useAppRouteParams = (): AppRouteParams => {
         justifiedBaseUrl: `/${lang}`,
       };
     }
-  }, [swapWithLangMatch]);
+  }, [swapWithLangMatch, chainId]);
 
   const swapMatchData = useMemo(() => {
     if (swapMatch) {
       const tokenFrom = transformAddressAliasToAddress(
-        swapMatch.params.tokenFrom
+        swapMatch.params.tokenFrom,
+        chainId
       );
-      const tokenTo = transformAddressAliasToAddress(swapMatch.params.tokenTo);
-      const tokenFromAlias = transformAddressToAddressAlias(tokenFrom);
-      const tokenToAlias = transformAddressToAddressAlias(tokenTo);
+      const tokenTo = transformAddressAliasToAddress(
+        swapMatch.params.tokenTo,
+        chainId
+      );
+      const tokenFromAlias = transformAddressToAddressAlias(tokenFrom, chainId);
+      const tokenToAlias = transformAddressToAddressAlias(tokenTo, chainId);
 
       return {
         tokenFrom,
@@ -121,7 +131,7 @@ const useAppRouteParams = (): AppRouteParams => {
         justifiedBaseUrl: "",
       };
     }
-  }, [swapMatch, userLanguage]);
+  }, [swapMatch, userLanguage, chainId]);
 
   const routeWithLangMatchData = useMemo(() => {
     if (routeWithLangMatch) {

--- a/src/hooks/useAppRouteParams.ts
+++ b/src/hooks/useAppRouteParams.ts
@@ -2,6 +2,10 @@ import { useMemo } from "react";
 import { useRouteMatch } from "react-router-dom";
 
 import {
+  transformAddressToAddressAlias,
+  transformAddressAliasToAddress,
+} from "../constants/addressAliases";
+import {
   DEFAULT_LOCALE,
   getUserLanguage,
   SUPPORTED_LOCALES,
@@ -14,6 +18,8 @@ export interface AppRouteParams {
   route?: AppRoutes;
   tokenFrom?: string;
   tokenTo?: string;
+  tokenFromAlias?: string;
+  tokenToAlias?: string;
   /**
    * Url from useRouteMatch
    */
@@ -67,16 +73,24 @@ const useAppRouteParams = (): AppRouteParams => {
       const lang =
         transformStringToSupportedLanguage(swapWithLangMatch.params.lang) ||
         DEFAULT_LOCALE;
-
-      const { tokenFrom, tokenTo } = swapWithLangMatch.params;
+      const tokenFrom = transformAddressAliasToAddress(
+        swapWithLangMatch.params.tokenFrom
+      );
+      const tokenTo = transformAddressAliasToAddress(
+        swapWithLangMatch.params.tokenTo
+      );
+      const tokenFromAlias = transformAddressToAddressAlias(tokenFrom);
+      const tokenToAlias = transformAddressToAddressAlias(tokenTo);
 
       return {
         lang,
         tokenFrom,
         tokenTo,
+        tokenFromAlias,
+        tokenToAlias,
         route: AppRoutes.swap,
         url: swapWithLangMatch.url,
-        urlWithoutLang: `/${AppRoutes.swap}/${swapWithLangMatch.params.tokenFrom}/${swapWithLangMatch.params.tokenTo}/`,
+        urlWithoutLang: `/${AppRoutes.swap}/${tokenFromAlias}/${tokenToAlias}/`,
         justifiedBaseUrl: `/${lang}`,
       };
     }
@@ -84,15 +98,22 @@ const useAppRouteParams = (): AppRouteParams => {
 
   const swapMatchData = useMemo(() => {
     if (swapMatch) {
-      const { tokenFrom, tokenTo } = swapMatch.params;
+      const tokenFrom = transformAddressAliasToAddress(
+        swapMatch.params.tokenFrom
+      );
+      const tokenTo = transformAddressAliasToAddress(swapMatch.params.tokenTo);
+      const tokenFromAlias = transformAddressToAddressAlias(tokenFrom);
+      const tokenToAlias = transformAddressToAddressAlias(tokenTo);
 
       return {
         tokenFrom,
         tokenTo,
+        readableTokenFrom: tokenFromAlias,
+        readableTokenTo: tokenToAlias,
         route: swapMatch.params.route,
         lang: userLanguage,
         url: swapMatch.url,
-        urlWithoutLang: swapMatch.url,
+        urlWithoutLang: `/${AppRoutes.swap}/${tokenFromAlias}/${tokenToAlias}/`,
         justifiedBaseUrl: "",
       };
     }

--- a/src/hooks/useAppRouteParams.ts
+++ b/src/hooks/useAppRouteParams.ts
@@ -98,7 +98,7 @@ const useAppRouteParams = (): AppRouteParams => {
         url: swapWithLangMatch.url,
         urlWithoutLang: `/${AppRoutes.swap}/${tokenFromAlias || tokenFrom}/${
           tokenToAlias || tokenTo
-        }/`,
+        }`,
         justifiedBaseUrl: `/${lang}`,
       };
     }
@@ -127,7 +127,7 @@ const useAppRouteParams = (): AppRouteParams => {
         url: swapMatch.url,
         urlWithoutLang: `/${AppRoutes.swap}/${tokenFromAlias || tokenFrom}/${
           tokenToAlias || tokenTo
-        }/`,
+        }`,
         justifiedBaseUrl: "",
       };
     }


### PR DESCRIPTION
Fixes #506 

I used constants/nativeCurrency.ts to get the name of native token. For example, an url could be:
- `swap/eth/0x5592ec0cfb4dbc12d3ab100b257153436a1f0fea`
- `swap/0xc778417e063141139fce010982780140aa0cd5ab/matic`
