### PR TITLE
513: Added getProgressBarAnimationProps helper and tests

### DIFF
--- a/src/components/ProgressBar/ProgressBar.styles.tsx
+++ b/src/components/ProgressBar/ProgressBar.styles.tsx
@@ -1,4 +1,3 @@
-import { motion } from "framer-motion";
 import styled from "styled-components/macro";
 
 export const Track = styled.div`
@@ -9,9 +8,15 @@ export const Track = styled.div`
   overflow: hidden;
 `;
 
-export const Progress = styled(motion.div)`
+interface ProgressBarProps {
+  initialWidth: number;
+  duration: number;
+}
+
+export const Progress = styled.div<ProgressBarProps>`
   height: 100%;
-  width: 100%;
+  width: ${(props) => props.initialWidth}%;
   background-color: ${(props) => props.theme.colors.primary};
   transform-origin: left;
+  transition: width ${(props) => props.duration}s linear;
 `;

--- a/src/components/ProgressBar/ProgressBar.styles.tsx
+++ b/src/components/ProgressBar/ProgressBar.styles.tsx
@@ -15,8 +15,9 @@ interface ProgressBarProps {
 
 export const Progress = styled.div<ProgressBarProps>`
   height: 100%;
-  width: ${(props) => props.initialWidth}%;
+  transform: scaleX(${({ initialWidth }) => initialWidth});
   background-color: ${(props) => props.theme.colors.primary};
   transform-origin: left;
-  transition: width ${(props) => props.duration}s linear;
+  transition: transform ${({ duration }) => duration}s linear;
+  will-change: transform;
 `;

--- a/src/components/ProgressBar/ProgressBar.tsx
+++ b/src/components/ProgressBar/ProgressBar.tsx
@@ -1,21 +1,30 @@
-import { FC } from "react";
+import { FC, useEffect, useState } from "react";
 
 import { Track, Progress } from "./ProgressBar.styles";
+import getProgressBarAnimationProps from "./helpers/getProgressBarAnimationProps";
 
 const ProgressBar: FC<{
   startTime: number;
   endTime: number;
 }> = ({ startTime, endTime }) => {
-  const now = Date.now();
-  const done = now - startTime;
-  const left = endTime - startTime;
-  const fractionDone = done / left;
+  const [isMounted, setIsMounted] = useState(false);
+
+  useEffect(() => {
+    setIsMounted(true);
+  }, []);
+
+  const { progress, duration } = getProgressBarAnimationProps(
+    new Date(startTime),
+    new Date(endTime),
+    new Date()
+  );
+
   return (
     <Track>
       <Progress
-        animate={{ scaleX: 1 }}
-        initial={{ scaleX: fractionDone }}
-        transition={{ ease: "linear", duration: left / 1000 }}
+        initialWidth={progress * 100}
+        duration={duration}
+        style={{ ...(isMounted && { width: "100%" }) }}
       />
     </Track>
   );

--- a/src/components/ProgressBar/ProgressBar.tsx
+++ b/src/components/ProgressBar/ProgressBar.tsx
@@ -9,11 +9,15 @@ const ProgressBar: FC<{
 }> = ({ startTime, endTime }) => {
   const [isMounted, setIsMounted] = useState(false);
 
+  // `isMounted` will be false until the component has rendered once. We use this
+  // so that we can set the initial width of the progress bar to correspond with
+  // the initial progress, before setting the "target" to 100% for the CSS transition
+
   useEffect(() => {
     setIsMounted(true);
   }, []);
 
-  const { progress, duration } = getProgressBarAnimationProps(
+  const { initialProgress, duration } = getProgressBarAnimationProps(
     new Date(startTime),
     new Date(endTime),
     new Date()
@@ -22,9 +26,9 @@ const ProgressBar: FC<{
   return (
     <Track>
       <Progress
-        initialWidth={progress * 100}
+        initialWidth={initialProgress}
         duration={duration}
-        style={{ ...(isMounted && { width: "100%" }) }}
+        style={{ ...(isMounted && { transform: "scaleX(1)" }) }}
       />
     </Track>
   );

--- a/src/components/ProgressBar/helpers/getProgressBarAnimationProps.spec.ts
+++ b/src/components/ProgressBar/helpers/getProgressBarAnimationProps.spec.ts
@@ -1,0 +1,35 @@
+import getProgressBarAnimationProps from "./getProgressBarAnimationProps";
+
+describe("getProgressBarAnimationProps", () => {
+  it("should return duration and progress", () => {
+    const result1 = getProgressBarAnimationProps(
+      new Date(1651259192230),
+      new Date(1651259309000),
+      new Date(1651259250615)
+    );
+    const result2 = getProgressBarAnimationProps(
+      new Date(1651259192230),
+      new Date(1651259309000),
+      new Date(1651269309000)
+    );
+    const result3 = getProgressBarAnimationProps(
+      new Date(1651259192230),
+      new Date(1651259309000),
+      new Date(1651259092230)
+    );
+    const result4 = getProgressBarAnimationProps(
+      new Date(1651259192230),
+      new Date(1651259309000),
+      new Date(1651259192230)
+    );
+
+    expect(result1.duration).toBe(58.385);
+    expect(result1.progress).toBe(0.5);
+    expect(result2.duration).toBe(0);
+    expect(result2.progress).toBe(1);
+    expect(result3.duration).toBe(116.77);
+    expect(result3.progress).toBe(0);
+    expect(result4.duration).toBe(116.77);
+    expect(result4.progress).toBe(0);
+  });
+});

--- a/src/components/ProgressBar/helpers/getProgressBarAnimationProps.spec.ts
+++ b/src/components/ProgressBar/helpers/getProgressBarAnimationProps.spec.ts
@@ -24,12 +24,12 @@ describe("getProgressBarAnimationProps", () => {
     );
 
     expect(result1.duration).toBe(58.385);
-    expect(result1.progress).toBe(0.5);
+    expect(result1.initialProgress).toBe(0.5);
     expect(result2.duration).toBe(0);
-    expect(result2.progress).toBe(1);
+    expect(result2.initialProgress).toBe(1);
     expect(result3.duration).toBe(116.77);
-    expect(result3.progress).toBe(0);
+    expect(result3.initialProgress).toBe(0);
     expect(result4.duration).toBe(116.77);
-    expect(result4.progress).toBe(0);
+    expect(result4.initialProgress).toBe(0);
   });
 });

--- a/src/components/ProgressBar/helpers/getProgressBarAnimationProps.ts
+++ b/src/components/ProgressBar/helpers/getProgressBarAnimationProps.ts
@@ -2,7 +2,7 @@ interface ProgressBarAnimationProps {
   /**
    * Progression since startTime compared to now, number between 0 and 1.
    */
-  progress: number; // Progress
+  initialProgress: number;
   /**
    * Difference of startTime and endTime in seconds divided by progress ;
    */
@@ -21,6 +21,6 @@ export default function getProgressBarAnimationProps(
 
   return {
     duration: durationLeftInSeconds,
-    progress,
+    initialProgress: progress,
   };
 }

--- a/src/components/ProgressBar/helpers/getProgressBarAnimationProps.ts
+++ b/src/components/ProgressBar/helpers/getProgressBarAnimationProps.ts
@@ -1,0 +1,26 @@
+interface ProgressBarAnimationProps {
+  /**
+   * Progression since startTime compared to now, number between 0 and 1.
+   */
+  progress: number; // Progress
+  /**
+   * Difference of startTime and endTime in seconds divided by progress ;
+   */
+  duration: number;
+}
+
+export default function getProgressBarAnimationProps(
+  startTime: Date,
+  endTime: Date,
+  now: Date
+): ProgressBarAnimationProps {
+  const totalDuration = endTime.getTime() - startTime.getTime();
+  const durationLeft = Math.max(endTime.getTime() - now.getTime(), 0);
+  const progress = Math.max(1 - durationLeft / totalDuration, 0);
+  const durationLeftInSeconds = ((1 - progress) * totalDuration) / 1000;
+
+  return {
+    duration: durationLeftInSeconds,
+    progress,
+  };
+}


### PR DESCRIPTION
Fixes #513 

There were 2 problems:
- Logic for calculating time left and progress was not working.
- Framer-motion not reacting well to restarting animations

So I rewrote logic and added helper with some tests and did animations with simple css.