### PR TITLE
Fix potential race condition causing bad UI state

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@testing-library/jest-dom": "^5.14.1",
     "@testing-library/react": "^11.2.7",
     "@testing-library/user-event": "^13.2.1",
-    "@types/jest": "^24.0.0",
+    "@types/jest": "^26.0.0",
     "@types/node": "^12.0.0",
     "@types/react": "^17.0.16",
     "@types/react-dom": "^17.0.9",

--- a/src/constants/configParams.ts
+++ b/src/constants/configParams.ts
@@ -6,6 +6,14 @@
 export const RFQ_EXPIRY_BUFFER_MS = 60 * 1000;
 
 /**
+ * In the event that an order has an expiry very close to RFQ_EXPIRY_BUFFER
+ * we will re-request it closer to the expiry than we would otherwise to prevent
+ * constantly re-requesting orders. This gives the user a fair amount of time to
+ * evaluate and accept the order.
+ */
+export const RFQ_MINIMUM_REREQUEST_DELAY_MS = 30 * 1000;
+
+/**
  * Time in seconds of last look order expiry duration
  */
 export const LAST_LOOK_ORDER_EXPIRY_SEC = 2 * 60;

--- a/src/features/orders/orderApi.ts
+++ b/src/features/orders/orderApi.ts
@@ -139,7 +139,7 @@ export function orderSortingFunction(a: Order, b: Order) {
   }
   // If tokens transferred are the same
   if (a.signerAmount === b.signerAmount && a.senderAmount === b.senderAmount) {
-    return aTimeToExpiry - bTimeToExpiry;
+    return parseInt(b.expiry) - parseInt(a.expiry);
   }
   if (a.signerAmount === b.signerAmount) {
     // Likely senderSide

--- a/src/features/orders/orderApi.ts
+++ b/src/features/orders/orderApi.ts
@@ -15,6 +15,8 @@ import {
   utils,
 } from "ethers";
 
+import { RFQ_EXPIRY_BUFFER_MS } from "../../constants/configParams";
+
 const REQUEST_ORDER_TIMEOUT_MS = 5000;
 
 const erc20Interface = new ethers.utils.Interface(erc20Abi);
@@ -118,9 +120,26 @@ export async function takeOrder(
 }
 
 export function orderSortingFunction(a: Order, b: Order) {
+  const now = Date.now();
+  const aTimeToExpiry = now - parseInt(a.expiry);
+  const bTimeToExpiry = now - parseInt(b.expiry);
+
+  // If any of the orders come in with an expiry that is less than our required
+  // buffer, put them to the bottom of the list.
+  if (
+    aTimeToExpiry < RFQ_EXPIRY_BUFFER_MS &&
+    bTimeToExpiry >= RFQ_EXPIRY_BUFFER_MS
+  ) {
+    return 1; // prefer B
+  } else if (
+    bTimeToExpiry < RFQ_EXPIRY_BUFFER_MS &&
+    aTimeToExpiry >= RFQ_EXPIRY_BUFFER_MS
+  ) {
+    return -1; // prefer A
+  }
   // If tokens transferred are the same
   if (a.signerAmount === b.signerAmount && a.senderAmount === b.senderAmount) {
-    return parseInt(b.expiry) - parseInt(a.expiry);
+    return bTimeToExpiry - aTimeToExpiry;
   }
   if (a.signerAmount === b.signerAmount) {
     // Likely senderSide

--- a/src/features/orders/orderApi.ts
+++ b/src/features/orders/orderApi.ts
@@ -139,7 +139,7 @@ export function orderSortingFunction(a: Order, b: Order) {
   }
   // If tokens transferred are the same
   if (a.signerAmount === b.signerAmount && a.senderAmount === b.senderAmount) {
-    return bTimeToExpiry - aTimeToExpiry;
+    return aTimeToExpiry - bTimeToExpiry;
   }
   if (a.signerAmount === b.signerAmount) {
     // Likely senderSide

--- a/src/features/orders/ordersSlice.spec.ts
+++ b/src/features/orders/ordersSlice.spec.ts
@@ -1,7 +1,17 @@
 import { RootState } from "../../app/store";
 import ordersReducer, { OrdersState, selectBestOrder } from "./ordersSlice";
 
+const RealDate = Date.now;
+
 describe("orders reducer", () => {
+  beforeEach(() => {
+    global.Date.now = jest.fn(() => new Date("2022-01-01T00:00:00Z").getTime());
+  });
+
+  afterEach(() => {
+    global.Date.now = RealDate;
+  });
+
   const initialState: OrdersState = {
     orders: [],
     errors: [],

--- a/src/features/orders/ordersSlice.spec.ts
+++ b/src/features/orders/ordersSlice.spec.ts
@@ -1,17 +1,7 @@
 import { RootState } from "../../app/store";
 import ordersReducer, { OrdersState, selectBestOrder } from "./ordersSlice";
 
-const RealDate = Date.now;
-
-describe("orders reducer", () => {
-  beforeEach(() => {
-    global.Date.now = jest.fn(() => new Date("2022-01-01T00:00:00Z").getTime());
-  });
-
-  afterEach(() => {
-    global.Date.now = RealDate;
-  });
-
+describe.only("orders reducer", () => {
   const initialState: OrdersState = {
     orders: [],
     errors: [],
@@ -94,6 +84,8 @@ describe("orders reducer", () => {
   });
 
   it("should select orders based on longest expiry if token amounts are equal", () => {
+    jest.useFakeTimers("modern").setSystemTime(new Date(1654763676396));
+
     // @ts-ignore (don't need to populate entire rootstate)
     const state: RootState = {
       orders: {
@@ -103,23 +95,24 @@ describe("orders reducer", () => {
             ...ignoredOrderProps,
             senderAmount: "7",
             signerAmount: "7",
-            expiry: "1",
+            expiry: "1654762976",
           },
           {
             ...ignoredOrderProps,
             senderAmount: "7",
             signerAmount: "7",
-            expiry: "3",
+            expiry: "1654763976",
           },
           {
             ...ignoredOrderProps,
             senderAmount: "7",
             signerAmount: "7",
-            expiry: "2",
+            expiry: "1654764000",
           },
         ],
       },
     };
-    expect(selectBestOrder(state).expiry).toBe("3");
+    expect(selectBestOrder(state).expiry).toBe("1654764000");
+    jest.useRealTimers();
   });
 });

--- a/src/features/orders/ordersSlice.ts
+++ b/src/features/orders/ordersSlice.ts
@@ -301,7 +301,7 @@ export const request = createAsyncThunk(
       // so do all the others. Return an empty order array as none are viable.
       if (expiry - now < RFQ_EXPIRY_BUFFER_MS) return [];
 
-      const timeTilReRequest = Math.min(
+      const timeTilReRequest = Math.max(
         expiry - now - RFQ_EXPIRY_BUFFER_MS,
         RFQ_MINIMUM_REREQUEST_DELAY_MS
       );

--- a/yarn.lock
+++ b/yarn.lock
@@ -2260,15 +2260,6 @@
     source-map "^0.6.1"
     write-file-atomic "^3.0.0"
 
-"@jest/types@^24.9.0":
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/@jest/types/-/types-24.9.0.tgz#63cb26cb7500d069e5a389441a7c6ab5e909fc59"
-  integrity sha512-XKK7ze1apu5JWQ5eZjHITP66AX+QsLlbaJRBGYr8pNzwcAE2JVkwnf0yqjHTsDRcjR0mujy/NmZMXw5kl+kGBw==
-  dependencies:
-    "@types/istanbul-lib-coverage" "^2.0.0"
-    "@types/istanbul-reports" "^1.1.1"
-    "@types/yargs" "^13.0.0"
-
 "@jest/types@^26.6.0", "@jest/types@^26.6.2":
   version "26.6.2"
   resolved "https://registry.yarnpkg.com/@jest/types/-/types-26.6.2.tgz#bef5a532030e1d88a2f5a6d933f84e97226ed48e"
@@ -3637,14 +3628,6 @@
   dependencies:
     "@types/istanbul-lib-coverage" "*"
 
-"@types/istanbul-reports@^1.1.1":
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/@types/istanbul-reports/-/istanbul-reports-1.1.2.tgz#e875cc689e47bce549ec81f3df5e6f6f11cfaeb2"
-  integrity sha512-P/W9yOX/3oPZSpaYOCQzGqgCQRXn0FFO/V8bWrCQs+wLmvVVxk6CRBXALEvNs9OHIatlnlFokfhuDo2ug01ciw==
-  dependencies:
-    "@types/istanbul-lib-coverage" "*"
-    "@types/istanbul-lib-report" "*"
-
 "@types/istanbul-reports@^3.0.0":
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/@types/istanbul-reports/-/istanbul-reports-3.0.1.tgz#9153fe98bba2bd565a63add9436d6f0d7f8468ff"
@@ -3660,12 +3643,13 @@
     jest-diff "^27.0.0"
     pretty-format "^27.0.0"
 
-"@types/jest@^24.0.0":
-  version "24.9.1"
-  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-24.9.1.tgz#02baf9573c78f1b9974a5f36778b366aa77bd534"
-  integrity sha512-Fb38HkXSVA4L8fGKEZ6le5bB8r6MRWlOCZbVuWZcmOMSCd2wCYOwN1ibj8daIoV9naq7aaOZjrLCoCMptKU/4Q==
+"@types/jest@^26.0.0":
+  version "26.0.24"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-26.0.24.tgz#943d11976b16739185913a1936e0de0c4a7d595a"
+  integrity sha512-E/X5Vib8BWqZNRlDxj9vYXhsDwPYbPINqKF9BsnSoon4RQ0D9moEuLD8txgyypFLH7J4+Lho9Nr/c8H0Fi+17w==
   dependencies:
-    jest-diff "^24.3.0"
+    jest-diff "^26.0.0"
+    pretty-format "^26.0.0"
 
 "@types/json-schema@*", "@types/json-schema@^7.0.3", "@types/json-schema@^7.0.4", "@types/json-schema@^7.0.5", "@types/json-schema@^7.0.7", "@types/json-schema@^7.0.8":
   version "7.0.9"
@@ -3982,13 +3966,6 @@
   version "20.2.1"
   resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-20.2.1.tgz#3b9ce2489919d9e4fea439b76916abc34b2df129"
   integrity sha512-7tFImggNeNBVMsn0vLrpn1H1uPrUBdnARPTpZoitY37ZrdJREzf7I16tMrlK3hen349gr1NYh8CmZQa7CTG6Aw==
-
-"@types/yargs@^13.0.0":
-  version "13.0.12"
-  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-13.0.12.tgz#d895a88c703b78af0465a9de88aa92c61430b092"
-  integrity sha512-qCxJE1qgz2y0hA4pIxjBR+PelCH0U5CK1XJXFwCNqfmliatKp47UCXXE9Dyk1OXBDLvsCF57TqQEJaeLfDYEOQ==
-  dependencies:
-    "@types/yargs-parser" "*"
 
 "@types/yargs@^15.0.0":
   version "15.0.14"
@@ -4702,7 +4679,7 @@ ansi-regex@^2.0.0:
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"
   integrity sha1-w7M6te42DYbg5ijwRorn7yfWVN8=
 
-ansi-regex@^4.0.0, ansi-regex@^4.1.0:
+ansi-regex@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.1.0.tgz#8b9f8f08cf1acb843756a839ca8c7e3168c51997"
   integrity sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==
@@ -5910,7 +5887,7 @@ ccount@^1.0.0:
   resolved "https://registry.yarnpkg.com/ccount/-/ccount-1.1.0.tgz#246687debb6014735131be8abab2d93898f8d043"
   integrity sha512-vlNK021QdI7PNeiUh/lKkC/mNHHfV0m/Ad5JoI0TYtlBnJAslM/JIkm/tGC88bkLIwO6OQ5uV6ztS6kVAtCDlg==
 
-chalk@2.4.2, chalk@^2.0.0, chalk@^2.0.1, chalk@^2.4.1, chalk@^2.4.2:
+chalk@2.4.2, chalk@^2.0.0, chalk@^2.4.1, chalk@^2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
   integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
@@ -7143,11 +7120,6 @@ detect-port@^1.3.0:
   dependencies:
     address "^1.0.1"
     debug "^2.6.0"
-
-diff-sequences@^24.9.0:
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-24.9.0.tgz#5715d6244e2aa65f48bba0bc972db0b0b11e95b5"
-  integrity sha512-Dj6Wk3tWyTE+Fo1rW8v0Xhwk80um6yFYKbuAxc9c3EZxIHFDYwbi34Uk42u1CdnIiVorvt4RmlSDjIPyzGC2ew==
 
 diff-sequences@^26.6.2:
   version "26.6.2"
@@ -10598,17 +10570,7 @@ jest-config@^26.6.3:
     micromatch "^4.0.2"
     pretty-format "^26.6.2"
 
-jest-diff@^24.3.0:
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-24.9.0.tgz#931b7d0d5778a1baf7452cb816e325e3724055da"
-  integrity sha512-qMfrTs8AdJE2iqrTp0hzh7kTd2PQWrsFyj9tORoKmu32xjPjeE4NyjVRDz8ybYwqS2ik8N4hsIpiVTyFeo2lBQ==
-  dependencies:
-    chalk "^2.0.1"
-    diff-sequences "^24.9.0"
-    jest-get-type "^24.9.0"
-    pretty-format "^24.9.0"
-
-jest-diff@^26.6.2:
+jest-diff@^26.0.0, jest-diff@^26.6.2:
   version "26.6.2"
   resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-26.6.2.tgz#1aa7468b52c3a68d7d5c5fdcdfcd5e49bd164394"
   integrity sha512-6m+9Z3Gv9wN0WFVasqjCL/06+EFCMTqDEUl/b87HYK2rAPTyfz4ZIuSlPhY51PIQRWx5TaxeF1qmXKe9gfN3sA==
@@ -10670,11 +10632,6 @@ jest-environment-node@^26.6.2:
     "@types/node" "*"
     jest-mock "^26.6.2"
     jest-util "^26.6.2"
-
-jest-get-type@^24.9.0:
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-24.9.0.tgz#1684a0c8a50f2e4901b6644ae861f579eed2ef0e"
-  integrity sha512-lUseMzAley4LhIcpSP9Jf+fTrQ4a1yHQwLNeeVa2cEmbCGeoZAtYPOIv8JaxLD/sUpKxetKGP+gsHl8f8TSj8Q==
 
 jest-get-type@^26.3.0:
   version "26.3.0"
@@ -13657,17 +13614,7 @@ pretty-error@^2.1.1:
     lodash "^4.17.20"
     renderkid "^2.0.4"
 
-pretty-format@^24.9.0:
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-24.9.0.tgz#12fac31b37019a4eea3c11aa9a959eb7628aa7c9"
-  integrity sha512-00ZMZUiHaJrNfk33guavqgvfJS30sLYf0f8+Srklv0AMPodGGHcoHgksZ3OThYnIvOd+8yMCn0YiEOogjlgsnA==
-  dependencies:
-    "@jest/types" "^24.9.0"
-    ansi-regex "^4.0.0"
-    ansi-styles "^3.2.0"
-    react-is "^16.8.4"
-
-pretty-format@^26.6.0, pretty-format@^26.6.2:
+pretty-format@^26.0.0, pretty-format@^26.6.0, pretty-format@^26.6.2:
   version "26.6.2"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-26.6.2.tgz#e35c2705f14cb7fe2fe94fa078345b444120fc93"
   integrity sha512-7AeGuCYNGmycyQbCqd/3PWH4eOoX/OiCa0uphp57NVTeAGdJGaAliecxwBDHYQCIvrW7aDBZCYeNTP/WX69mkg==
@@ -14210,7 +14157,7 @@ react-is@17.0.2, react-is@^17.0.1, react-is@^17.0.2:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
   integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
 
-react-is@^16.13.1, react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.4:
+react-is@^16.13.1, react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==


### PR DESCRIPTION
Fixes #521 

Copied from my response in the issue itself:

> I've checked out the code quite extensively and the only way I can see this could happen is a kind of race condition:
>
> - Orders are re-requested when we get to within 1M of the exiry
> - User clicks "new swap"
> - Response from makers comes in and populates the orders state before the user has a chance to do anything. Once there's an order in the orders state the SwapWidget changes its behaviour and could cause the state displayed in the screenshot.
>
> To mitigate this I'll do a couple of things:
>
> - Cancel the re-request when take is successfully fulfilled (it's currently only being cancelled when we click "new swap")
> - Don't update the orders slice with orders if its state wasn't "requesting".

Note that I couldn't reproduce this issue, but theoretically you could do so if you are running a maker by artificially introducing a long delay before responding, and ensuring you click "New swap" just after the request has gone out