### PR TITLE
feature/565 dropdown component

### DIFF
--- a/src/components/Dropdown/Dropdown.stories.tsx
+++ b/src/components/Dropdown/Dropdown.stories.tsx
@@ -1,0 +1,37 @@
+import React from "react";
+
+import { Story, Meta } from "@storybook/react";
+
+import { ThemeProvider } from "styled-components";
+
+import { darkTheme, lightTheme } from "../../style/themes";
+import { Dropdown, DropdownProps, SelectOption } from "./Dropdown";
+
+export default {
+  title: "components/Dropdown",
+  component: Dropdown,
+  argTypes: {
+    label: { control: { type: "string" } },
+    name: { control: { type: "string" } },
+    value: { control: { type: "SelectOption" } },
+    options: { control: { type: "SelectOption[]" } },
+    // onChange: { control: { type: "function" } },
+  },
+} as Meta;
+
+const Template: Story<DropdownProps> = (args) => <Dropdown {...args} />;
+
+export const Time = Template.bind({});
+Time.args = {
+  category: {
+    label: "SELECT TIME:",
+    value: "0",
+  },
+  options: [
+    { label: "MINUTE", value: "60" },
+    { label: "HOUR", value: "50" },
+    { label: "DAY", value: "4" },
+    { label: "WEEK", value: "3" },
+  ],
+  onChange: (option: SelectOption) => {},
+};

--- a/src/components/Dropdown/Dropdown.styles.tsx
+++ b/src/components/Dropdown/Dropdown.styles.tsx
@@ -1,0 +1,97 @@
+import styled from "styled-components";
+
+// theme, fonts, and dimensions are currently hardcoded
+// needs to take in a prop with the relevant dimensions from the parent
+
+export const Item = styled.div`
+  display: none;
+  position: relative;
+  text-align: center;
+  height: 25px;
+  width: 100px;
+  padding-left: 5px;
+
+  &.selected {
+    display: flex;
+    background-color: black;
+    border: 1px solid grey;
+    border-right: none;
+    align-items: center;
+  }
+`;
+
+export const Arrow = styled.div`
+  position: relative;
+  border: 1px solid grey;
+  border-radius: 0 10px 10px 0;
+  border-left: none;
+  height: 25px;
+  padding-left: 5px;
+  padding-right: 5px;
+  display: flex;
+  align-items: center;
+`;
+
+export const Selector = styled.div`
+  display: block;
+  cursor: pointer;
+  position: relative;
+  width: fit-content;
+  height: fit-content;
+  border-radius: 5px;
+  z-index: 1;
+
+  &.show > ${Item} {
+    display: flex;
+    align-items: center;
+    color: blue;
+  }
+`;
+
+export const Wrapper = styled.div`
+  font-size: 0.6rem;
+  font-weight: bold;
+  color: white;
+`;
+
+export const AbsoluteWrapper = styled.div`
+  background-color: black;
+  position: absolute;
+  display: flex;
+  height: 25px;
+
+  & > .show {
+    border: 1px solid grey;
+    border-radius: 0 10px 10px 0;
+  }
+
+  &.show > ${Selector} {
+    background-color: black;
+    border-radius: 0 0 5px 5px;
+    border: 1px solid grey;
+    overflow: hidden;
+  }
+
+  &.show > ${Selector} > ${Item} {
+    display: flex;
+    align-items: center;
+  }
+
+  &.show > ${Selector} > .selected {
+    border: none;
+  }
+
+  &.show > ${Selector} > .category {
+    background: grey;
+    border-bottom: 1px solid grey;
+  }
+
+  &.show > ${Arrow} > .icon {
+    color: black;
+  }
+
+  &.show > ${Arrow} {
+    padding-left: 4px;
+    color: black;
+  }
+`;

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -1,0 +1,69 @@
+import React, { useState } from "react";
+
+import Icon from "../Icon/Icon";
+import {
+  Selector,
+  Item,
+  Wrapper,
+  Arrow,
+  AbsoluteWrapper,
+} from "./Dropdown.styles";
+
+export type SelectOption = {
+  label: string;
+  value: string;
+};
+
+export type DropdownProps = {
+  category: SelectOption;
+  options: SelectOption[];
+  onChange: (option: SelectOption) => void;
+};
+
+export const Dropdown: React.FC<DropdownProps> = ({
+  category,
+  options,
+  onChange,
+}) => {
+  const [selectedOption, setSelectedOption] = useState(category);
+
+  function handleChange(newOption: SelectOption) {
+    setSelectedOption(newOption);
+    onChange(selectedOption);
+  }
+
+  return (
+    <Wrapper>
+      <AbsoluteWrapper
+        onClick={(event) => {
+          event.currentTarget.classList.toggle("show");
+        }}
+      >
+        <Selector>
+          <Item
+            className={`${
+              selectedOption === category ? "selected category" : "category"
+            }`}
+          >
+            <a>{selectedOption.label}</a>
+          </Item>
+          {options.map((option, index) => {
+            return (
+              <Item
+                className={`${selectedOption === option ? "selected" : ""}`}
+                onClick={() => {
+                  handleChange(options[index]);
+                }}
+              >
+                <a>{option.label}</a>
+              </Item>
+            );
+          })}
+        </Selector>
+        <Arrow>
+          <Icon name={"chevron-down"}></Icon>
+        </Arrow>
+      </AbsoluteWrapper>
+    </Wrapper>
+  );
+};


### PR DESCRIPTION
The JSX is formatted as divs rather than an option/select module to reduce the amount of boilerplate from the W3 example.

the label, name props were adjusted accordingly:

interface {
category: SelectOption,
options: SelectOption[],
onChange: (option: SelectOption) => void
}

Important note on the styling:

Will need to add styled-component props which allow for adjusting the dimensions of the component, as from my testing, they must have hardcoded width and height values in order to operate correctly. It's siblings in the parent element will share these traits so that it can interact as if it is in-flow with the parent, as the position: relative/absolute currently remove it from that state. Themes are also hardcoded at the moment, I will change these once I dig into the styled-component Theming the app has set up already. 

This took a lot of experimenting--let me know if I overlooked anything, as I changed a lot from the initial example in order for it to mostly follow the figma set up.
