### PR TITLE
Focus/OnClick bug fix

### DIFF
--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -38,7 +38,7 @@ export const Dropdown: React.FC<DropdownProps> = ({
             return (
               <Item
                 key={option.value}
-                onClick={() => {
+                onMouseDown={() => {
                   handleChange(option);
                 }}
               >


### PR DESCRIPTION
-Fixed small bug which was giving :focus precedence over onClick, thus closing the dropdown before firing change functions
- onClick is now replaced by onMouseDown