### PR TITLE
Feature/558 swap type selector

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -57,7 +57,8 @@
     "minutesShort": "Min",
     "hoursShort": "H",
     "daysShort": "D",
-    "weeksShort": "W"
+    "weeksShort": "W",
+    "for": "For"
   },
   "information": {
     "join.title": "Join AirSwap",
@@ -134,7 +135,7 @@
     "publiclyList": "Publicly list",
     "publiclyListDescription": "Allow others to publicly find my swap",
     "anyone": "Anyone",
-    "someone": "Someone",
+    "specificWallet": "Specific Wallet",
     "counterPartyAddress": "Counterpary address",
     "enterCounterPartyAddressOrENS": "Enter counterparty address or ENS"
   },

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -136,7 +136,7 @@
     "publiclyListDescription": "Allow others to publicly find my swap",
     "anyone": "Anyone",
     "specificWallet": "Specific Wallet",
-    "counterPartyAddress": "Counterpary address",
+    "counterPartyAddress": "Counterparty address",
     "enterCounterPartyAddressOrENS": "Enter counterparty address or ENS"
   },
   "toast": {

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -134,7 +134,9 @@
     "publiclyList": "Publicly list",
     "publiclyListDescription": "Allow others to publicly find my swap",
     "anyone": "Anyone",
-    "someone": "Someone"
+    "someone": "Someone",
+    "counterPartyAddress": "Counterpary address",
+    "enterCounterPartyAddressOrENS": "Enter counterparty address or ENS"
   },
   "toast": {
     "swapComplete": "Swap Complete",

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -132,7 +132,9 @@
     "revertPrice": "Revert price",
     "moreInformation": "More information",
     "publiclyList": "Publicly list",
-    "publiclyListDescription": "Allow others to publicly find my swap"
+    "publiclyListDescription": "Allow others to publicly find my swap",
+    "anyone": "Anyone",
+    "someone": "Someone"
   },
   "toast": {
     "swapComplete": "Swap Complete",

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -130,7 +130,9 @@
     "editCustomTokens": "Edit Custom Tokens",
     "settings": "Settings",
     "revertPrice": "Revert price",
-    "moreInformation": "More information"
+    "moreInformation": "More information",
+    "publiclyList": "Publicly list",
+    "publiclyListDescription": "Allow others to publicly find my swap"
   },
   "toast": {
     "swapComplete": "Swap Complete",

--- a/src/components/Button/Button.styles.tsx
+++ b/src/components/Button/Button.styles.tsx
@@ -1,5 +1,4 @@
-import { css } from "styled-components";
-import styled, { DefaultTheme } from "styled-components/macro";
+import styled, { css, DefaultTheme } from "styled-components/macro";
 
 import { ButtonIntent, ButtonJustifyContent } from "./Button";
 

--- a/src/components/Checkbox/Checkbox.styles.tsx
+++ b/src/components/Checkbox/Checkbox.styles.tsx
@@ -1,0 +1,75 @@
+import styled from "styled-components/macro";
+
+import { FlexAlignCenter, TextEllipsis } from "../../style/mixins";
+import Icon from "../Icon/Icon";
+
+export const CheckLabel = styled.label<{ isDisabled?: boolean }>`
+  display: flex;
+  align-items: center;
+  cursor: pointer;
+
+  ${({ isDisabled }) =>
+    isDisabled &&
+    `
+     pointer-events: none;
+     opacity: 0.5;
+  `}
+`;
+
+export const CheckContainer = styled.div`
+  ${FlexAlignCenter};
+
+  border: 1px solid ${(props) => props.theme.colors.lightGrey};
+  border-radius: 2px;
+  width: 1.5rem;
+  height: 1.5rem;
+`;
+
+export const CheckIcon = styled(Icon)`
+  display: none;
+`;
+
+export const LabelContainer = styled.div`
+  margin-left: 1rem;
+  width: calc(100% - 2.5rem);
+`;
+
+export const Label = styled.div`
+  ${TextEllipsis};
+
+  font-size: 0.75rem;
+  font-weight: 700;
+  line-height: 1.5;
+  text-transform: uppercase;
+`;
+
+export const SubLabel = styled.div`
+  ${TextEllipsis};
+
+  margin-top: -0.125rem;
+  font-size: 0.75rem;
+  font-weight: 400;
+  line-height: 1.5;
+  color: ${(props) => props.theme.colors.darkSubText};
+`;
+
+export const Input = styled.input`
+  position: absolute;
+  opacity: 0;
+
+  &:checked {
+    & ~ ${CheckContainer} {
+      border-color: ${(props) => props.theme.colors.primary};
+      background: ${(props) => props.theme.colors.primary};
+    }
+
+    & ~ ${CheckContainer} ${CheckIcon} {
+      display: block;
+    }
+  }
+
+  &:disabled ~ ${CheckContainer} {
+    border-color: ${(props) => props.theme.colors.grey};
+    background: ${(props) => props.theme.colors.grey};
+  }
+`;

--- a/src/components/Checkbox/Checkbox.styles.tsx
+++ b/src/components/Checkbox/Checkbox.styles.tsx
@@ -41,6 +41,8 @@ export const Label = styled.div`
   font-weight: 700;
   line-height: 1.5;
   text-transform: uppercase;
+  color: ${({ theme }) =>
+    theme.name === "dark" ? theme.colors.white : theme.colors.primary};
 `;
 
 export const SubLabel = styled.div`

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -26,15 +26,25 @@ const Checkbox: FC<CheckboxProps> = ({
   hideLabel,
   label,
   subLabel,
+  onChange,
   className,
 }) => {
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    onChange(e.target.checked);
+  };
+
   return (
     <CheckLabel
       aria-label={hideLabel ? label : undefined}
       isDisabled={disabled}
       className={className}
     >
-      <Input type="checkbox" checked={checked} disabled={disabled} />
+      <Input
+        checked={checked}
+        disabled={disabled}
+        type="checkbox"
+        onChange={handleChange}
+      />
       <CheckContainer>
         <CheckIcon name="check" iconSize={1} />
       </CheckContainer>

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -1,0 +1,49 @@
+import React, { FC } from "react";
+
+import {
+  CheckContainer,
+  CheckIcon,
+  CheckLabel,
+  Input,
+  Label,
+  LabelContainer,
+  SubLabel,
+} from "./Checkbox.styles";
+
+export type HTMLInputProps = JSX.IntrinsicElements["input"];
+
+interface CheckboxProps extends Omit<HTMLInputProps, "onChange"> {
+  hideLabel?: boolean;
+  label: string;
+  subLabel?: string;
+  onChange: (isChecked: boolean) => void;
+  className?: string;
+}
+
+const Checkbox: FC<CheckboxProps> = ({
+  checked,
+  disabled,
+  hideLabel,
+  label,
+  subLabel,
+  className,
+}) => {
+  return (
+    <CheckLabel
+      aria-label={hideLabel ? label : undefined}
+      isDisabled={disabled}
+      className={className}
+    >
+      <Input type="checkbox" checked={checked} disabled={disabled} />
+      <CheckContainer>
+        <CheckIcon name="check" iconSize={1} />
+      </CheckContainer>
+      <LabelContainer>
+        <Label>{label}</Label>
+        <SubLabel>{subLabel}</SubLabel>
+      </LabelContainer>
+    </CheckLabel>
+  );
+};
+
+export default Checkbox;

--- a/src/components/Dropdown/Dropdown.styles.tsx
+++ b/src/components/Dropdown/Dropdown.styles.tsx
@@ -172,3 +172,15 @@ export const Wrapper = styled.div`
     }
   }
 `;
+
+export const Sizer = styled.div`
+  ${ButtonStyle};
+
+  flex-direction: column;
+  align-items: flex-start;
+  position: absolute;
+  width: auto;
+  padding: 0;
+  pointer-events: none;
+  opacity: 0;
+`;

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -1,7 +1,6 @@
-import React, { useCallback, useState } from "react";
+import React, { FC, useCallback, useState } from "react";
 
 import Icon from "../Icon/Icon";
-import { Sizer } from "../MakeWidget/subcomponents/ExpirySelector/ExpirySelector.styles";
 import {
   Option,
   Wrapper,
@@ -9,6 +8,7 @@ import {
   Select,
   ItemBackground,
   SelectButtonText,
+  Sizer,
   NativeSelect,
   NativeSelectWrapper,
   NativeSelectIcon,
@@ -27,7 +27,9 @@ export type DropdownProps = {
   className?: string;
 };
 
-export const Dropdown: React.FC<DropdownProps> = ({
+export const Snavie = "test";
+
+const Dropdown: FC<DropdownProps> = ({
   selectedOption,
   options,
   onChange,
@@ -47,6 +49,7 @@ export const Dropdown: React.FC<DropdownProps> = ({
 
   const sizerRef = useCallback((node) => {
     if (node !== null) {
+      console.log(node.getBoundingClientRect());
       setSelectWidth(node.getBoundingClientRect().width);
     }
   }, []);
@@ -78,6 +81,8 @@ export const Dropdown: React.FC<DropdownProps> = ({
     // Unlike other browsers, on safari clicking a button won't focus it.
     e.currentTarget.focus();
   };
+
+  console.log(selectWidth);
 
   return (
     <Wrapper className={className}>
@@ -126,3 +131,5 @@ export const Dropdown: React.FC<DropdownProps> = ({
     </Wrapper>
   );
 };
+
+export default Dropdown;

--- a/src/components/InfoSection/InfoSection.styles.tsx
+++ b/src/components/InfoSection/InfoSection.styles.tsx
@@ -1,0 +1,18 @@
+import styled from "styled-components/macro";
+
+import Icon from "../Icon/Icon";
+
+export const Container = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  border: 1px solid ${(props) => props.theme.colors.borderGrey};
+  padding: 0.75rem 1rem;
+  background: ${({ theme }) =>
+    theme.name === "dark" ? theme.colors.darkGrey : theme.colors.primaryLight};
+`;
+
+export const StyledIcon = styled(Icon)`
+  color: ${({ theme }) =>
+    theme.name === "dark" ? theme.colors.white : theme.colors.darkSubText};
+`;

--- a/src/components/InfoSection/InfoSection.styles.tsx
+++ b/src/components/InfoSection/InfoSection.styles.tsx
@@ -2,7 +2,7 @@ import styled from "styled-components/macro";
 
 import Icon from "../Icon/Icon";
 
-export const Container = styled.div`
+export const Wrapper = styled.div`
   display: flex;
   align-items: center;
   justify-content: space-between;

--- a/src/components/InfoSection/InfoSection.styles.tsx
+++ b/src/components/InfoSection/InfoSection.styles.tsx
@@ -1,18 +1,18 @@
 import styled from "styled-components/macro";
 
-import Icon from "../Icon/Icon";
+import IconButton from "../IconButton/IconButton";
 
 export const Wrapper = styled.div`
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
+  display: grid;
+  grid-template-columns: calc(100% - 2rem) 2rem;
   border: 1px solid ${(props) => props.theme.colors.borderGrey};
+  width: 100%;
   padding: 0.75rem 1rem;
   background: ${({ theme }) =>
     theme.name === "dark" ? theme.colors.darkGrey : theme.colors.primaryLight};
 `;
 
-export const StyledIcon = styled(Icon)`
+export const StyledIconButton = styled(IconButton)`
   color: ${({ theme }) =>
     theme.name === "dark" ? theme.colors.white : theme.colors.darkSubText};
 `;

--- a/src/components/InfoSection/InfoSection.tsx
+++ b/src/components/InfoSection/InfoSection.tsx
@@ -1,0 +1,21 @@
+import React, { FC, PropsWithChildren } from "react";
+
+import { Container, StyledIcon } from "./InfoSection.styles";
+
+interface InfoSectionProps {
+  className?: string;
+}
+
+const InfoSection: FC<PropsWithChildren<InfoSectionProps>> = ({
+  children,
+  className,
+}) => {
+  return (
+    <Container className={className}>
+      {children}
+      <StyledIcon name="information-circle-outline" />
+    </Container>
+  );
+};
+
+export default InfoSection;

--- a/src/components/InfoSection/InfoSection.tsx
+++ b/src/components/InfoSection/InfoSection.tsx
@@ -1,6 +1,6 @@
 import React, { FC, PropsWithChildren } from "react";
 
-import { Container, StyledIcon } from "./InfoSection.styles";
+import { Wrapper, StyledIcon } from "./InfoSection.styles";
 
 interface InfoSectionProps {
   className?: string;
@@ -11,10 +11,10 @@ const InfoSection: FC<PropsWithChildren<InfoSectionProps>> = ({
   className,
 }) => {
   return (
-    <Container className={className}>
+    <Wrapper className={className}>
       {children}
       <StyledIcon name="information-circle-outline" />
-    </Container>
+    </Wrapper>
   );
 };
 

--- a/src/components/InfoSection/InfoSection.tsx
+++ b/src/components/InfoSection/InfoSection.tsx
@@ -1,6 +1,6 @@
 import React, { FC, PropsWithChildren } from "react";
 
-import { Wrapper, StyledIcon } from "./InfoSection.styles";
+import { Wrapper, StyledIconButton } from "./InfoSection.styles";
 
 interface InfoSectionProps {
   className?: string;
@@ -13,7 +13,7 @@ const InfoSection: FC<PropsWithChildren<InfoSectionProps>> = ({
   return (
     <Wrapper className={className}>
       {children}
-      <StyledIcon name="information-circle-outline" />
+      <StyledIconButton icon="information-circle-outline" />
     </Wrapper>
   );
 };

--- a/src/components/MakeWidget/MakeWidget.styles.tsx
+++ b/src/components/MakeWidget/MakeWidget.styles.tsx
@@ -1,11 +1,16 @@
 import styled from "styled-components/macro";
 
 import InfoSection from "../InfoSection/InfoSection";
+import OrderTypeSelector from "../OrderTypeSelector/OrderTypeSelector";
 
 export const Container = styled.div`
   display: flex;
   flex-direction: column;
   height: 100%;
+`;
+
+export const StyledOrderTypeSelector = styled(OrderTypeSelector)`
+  margin-top: 1rem;
 `;
 
 export const StyledInfoSection = styled(InfoSection)`

--- a/src/components/MakeWidget/MakeWidget.styles.tsx
+++ b/src/components/MakeWidget/MakeWidget.styles.tsx
@@ -1,7 +1,13 @@
 import styled from "styled-components/macro";
 
+import InfoSection from "../InfoSection/InfoSection";
+
 export const Container = styled.div`
   display: flex;
   flex-direction: column;
   height: 100%;
+`;
+
+export const StyledInfoSection = styled(InfoSection)`
+  margin-top: 1rem;
 `;

--- a/src/components/MakeWidget/MakeWidget.styles.tsx
+++ b/src/components/MakeWidget/MakeWidget.styles.tsx
@@ -1,7 +1,7 @@
 import styled from "styled-components/macro";
 
 import InfoSection from "../InfoSection/InfoSection";
-import OrderTypeSelector from "../OrderTypeSelector/OrderTypeSelector";
+import OrderTypeSelector from "./subcomponents/OrderTypeSelector/OrderTypeSelector";
 
 export const Container = styled.div`
   display: flex;

--- a/src/components/MakeWidget/MakeWidget.styles.tsx
+++ b/src/components/MakeWidget/MakeWidget.styles.tsx
@@ -1,6 +1,7 @@
 import styled from "styled-components/macro";
 
-import InfoSection from "../InfoSection/InfoSection";
+import AddressInput from "./subcomponents/AddressInput/AddressInput";
+import InfoSection from "./subcomponents/InfoSection/InfoSection";
 import OrderTypeSelector from "./subcomponents/OrderTypeSelector/OrderTypeSelector";
 
 export const Container = styled.div`
@@ -15,4 +16,10 @@ export const StyledOrderTypeSelector = styled(OrderTypeSelector)`
 
 export const StyledInfoSection = styled(InfoSection)`
   margin-top: 1rem;
+  height: 3.5rem;
+`;
+
+export const StyledAddressInput = styled(AddressInput)`
+  margin-top: 1rem;
+  height: 3.5rem;
 `;

--- a/src/components/MakeWidget/MakeWidget.tsx
+++ b/src/components/MakeWidget/MakeWidget.tsx
@@ -1,16 +1,44 @@
-import React, { FC } from "react";
+import React, { FC, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useHistory } from "react-router-dom";
 
+import { OrderScopeType, OrderType } from "../../types/orderTypes";
 import Checkbox from "../Checkbox/Checkbox";
+import { SelectOption } from "../Dropdown/Dropdown";
 import SwapInputs from "../SwapInputs/SwapInputs";
-import { Container, StyledInfoSection } from "./MakeWidget.styles";
+import {
+  Container,
+  StyledInfoSection,
+  StyledOrderTypeSelector,
+} from "./MakeWidget.styles";
+import { getOrderTypeSelectOptions } from "./helpers";
 import ActionButtons from "./subcomponents/ActionButtons/ActionButtons";
 import MakeWidgetHeader from "./subcomponents/MakeWidgetHeader/MakeWidgetHeader";
 
 const MakeWidget: FC = () => {
   const { t } = useTranslation();
   const history = useHistory();
+
+  const orderTypeSelectOptions = useMemo(
+    () => getOrderTypeSelectOptions(t),
+    [t]
+  );
+
+  const [orderType, setOrderType] = useState<OrderType>(OrderType.publicListed);
+  const [orderScopeTypeOption, setOrderScopeTypeOption] =
+    useState<SelectOption>(orderTypeSelectOptions[0]);
+
+  useEffect(() => {
+    if (orderScopeTypeOption.value === OrderScopeType.private) {
+      return setOrderType(OrderType.private);
+    }
+
+    return setOrderType(OrderType.publicListed);
+  }, [orderScopeTypeOption]);
+
+  const handleOrderTypeCheckboxChange = (isChecked: boolean) => {
+    setOrderType(isChecked ? OrderType.publicListed : OrderType.publicUnlisted);
+  };
 
   const handleBackButtonClick = () => {
     history.goBack();
@@ -30,11 +58,17 @@ const MakeWidget: FC = () => {
         onChangeTokenClick={() => {}}
         onMaxButtonClick={() => {}}
       />
+      <StyledOrderTypeSelector
+        options={orderTypeSelectOptions}
+        selectedOrderTypeOption={orderScopeTypeOption}
+        onChange={setOrderScopeTypeOption}
+      />
       <StyledInfoSection>
         <Checkbox
+          checked={orderType === OrderType.publicListed}
           label={t("orders.publiclyList")}
           subLabel={t("orders.publiclyListDescription")}
-          onChange={console.log}
+          onChange={handleOrderTypeCheckboxChange}
         />
       </StyledInfoSection>
       <ActionButtons

--- a/src/components/MakeWidget/MakeWidget.tsx
+++ b/src/components/MakeWidget/MakeWidget.tsx
@@ -8,12 +8,12 @@ import { SelectOption } from "../Dropdown/Dropdown";
 import SwapInputs from "../SwapInputs/SwapInputs";
 import {
   Container,
+  StyledAddressInput,
   StyledInfoSection,
   StyledOrderTypeSelector,
 } from "./MakeWidget.styles";
 import { getOrderTypeSelectOptions } from "./helpers";
 import ActionButtons from "./subcomponents/ActionButtons/ActionButtons";
-import AddressInput from "./subcomponents/AddressInput/AddressInput";
 import MakeWidgetHeader from "./subcomponents/MakeWidgetHeader/MakeWidgetHeader";
 
 const MakeWidget: FC = () => {
@@ -65,18 +65,18 @@ const MakeWidget: FC = () => {
         selectedOrderTypeOption={orderScopeTypeOption}
         onChange={setOrderScopeTypeOption}
       />
-      <StyledInfoSection>
-        {orderType === OrderType.private ? (
-          <AddressInput value={address} onChange={setAddress} />
-        ) : (
+      {orderType === OrderType.private ? (
+        <StyledAddressInput value={address} onChange={setAddress} />
+      ) : (
+        <StyledInfoSection>
           <Checkbox
             checked={orderType === OrderType.publicListed}
             label={t("orders.publiclyList")}
             subLabel={t("orders.publiclyListDescription")}
             onChange={handleOrderTypeCheckboxChange}
           />
-        )}
-      </StyledInfoSection>
+        </StyledInfoSection>
+      )}
       <ActionButtons
         onBackButtonClick={handleBackButtonClick}
         onSignButtonClick={() => {}}

--- a/src/components/MakeWidget/MakeWidget.tsx
+++ b/src/components/MakeWidget/MakeWidget.tsx
@@ -4,7 +4,7 @@ import { useHistory } from "react-router-dom";
 
 import Checkbox from "../Checkbox/Checkbox";
 import SwapInputs from "../SwapInputs/SwapInputs";
-import { Container } from "./MakeWidget.styles";
+import { Container, StyledInfoSection } from "./MakeWidget.styles";
 import ActionButtons from "./subcomponents/ActionButtons/ActionButtons";
 import MakeWidgetHeader from "./subcomponents/MakeWidgetHeader/MakeWidgetHeader";
 
@@ -30,11 +30,13 @@ const MakeWidget: FC = () => {
         onChangeTokenClick={() => {}}
         onMaxButtonClick={() => {}}
       />
-      <Checkbox
-        label="Publicy list"
-        subLabel="Allow others to publicly find my swap"
-        onChange={console.log}
-      />
+      <StyledInfoSection>
+        <Checkbox
+          label={t("orders.publiclyList")}
+          subLabel={t("orders.publiclyListDescription")}
+          onChange={console.log}
+        />
+      </StyledInfoSection>
       <ActionButtons
         onBackButtonClick={handleBackButtonClick}
         onSignButtonClick={() => {}}

--- a/src/components/MakeWidget/MakeWidget.tsx
+++ b/src/components/MakeWidget/MakeWidget.tsx
@@ -13,6 +13,7 @@ import {
 } from "./MakeWidget.styles";
 import { getOrderTypeSelectOptions } from "./helpers";
 import ActionButtons from "./subcomponents/ActionButtons/ActionButtons";
+import AddressInput from "./subcomponents/AddressInput/AddressInput";
 import MakeWidgetHeader from "./subcomponents/MakeWidgetHeader/MakeWidgetHeader";
 
 const MakeWidget: FC = () => {
@@ -27,6 +28,7 @@ const MakeWidget: FC = () => {
   const [orderType, setOrderType] = useState<OrderType>(OrderType.publicListed);
   const [orderScopeTypeOption, setOrderScopeTypeOption] =
     useState<SelectOption>(orderTypeSelectOptions[0]);
+  const [address, setAddress] = useState("");
 
   useEffect(() => {
     if (orderScopeTypeOption.value === OrderScopeType.private) {
@@ -65,7 +67,7 @@ const MakeWidget: FC = () => {
       />
       <StyledInfoSection>
         {orderType === OrderType.private ? (
-          "input"
+          <AddressInput value={address} onChange={setAddress} />
         ) : (
           <Checkbox
             checked={orderType === OrderType.publicListed}

--- a/src/components/MakeWidget/MakeWidget.tsx
+++ b/src/components/MakeWidget/MakeWidget.tsx
@@ -2,6 +2,7 @@ import React, { FC } from "react";
 import { useTranslation } from "react-i18next";
 import { useHistory } from "react-router-dom";
 
+import Checkbox from "../Checkbox/Checkbox";
 import SwapInputs from "../SwapInputs/SwapInputs";
 import { Container } from "./MakeWidget.styles";
 import ActionButtons from "./subcomponents/ActionButtons/ActionButtons";
@@ -28,6 +29,11 @@ const MakeWidget: FC = () => {
         onBaseAmountChange={() => {}}
         onChangeTokenClick={() => {}}
         onMaxButtonClick={() => {}}
+      />
+      <Checkbox
+        label="Publicy list"
+        subLabel="Allow others to publicly find my swap"
+        onChange={console.log}
       />
       <ActionButtons
         onBackButtonClick={handleBackButtonClick}

--- a/src/components/MakeWidget/MakeWidget.tsx
+++ b/src/components/MakeWidget/MakeWidget.tsx
@@ -64,12 +64,16 @@ const MakeWidget: FC = () => {
         onChange={setOrderScopeTypeOption}
       />
       <StyledInfoSection>
-        <Checkbox
-          checked={orderType === OrderType.publicListed}
-          label={t("orders.publiclyList")}
-          subLabel={t("orders.publiclyListDescription")}
-          onChange={handleOrderTypeCheckboxChange}
-        />
+        {orderType === OrderType.private ? (
+          "input"
+        ) : (
+          <Checkbox
+            checked={orderType === OrderType.publicListed}
+            label={t("orders.publiclyList")}
+            subLabel={t("orders.publiclyListDescription")}
+            onChange={handleOrderTypeCheckboxChange}
+          />
+        )}
       </StyledInfoSection>
       <ActionButtons
         onBackButtonClick={handleBackButtonClick}

--- a/src/components/MakeWidget/helpers/index.ts
+++ b/src/components/MakeWidget/helpers/index.ts
@@ -1,0 +1,17 @@
+import { TFunction } from "i18next";
+
+import { OrderScopeType } from "../../../types/orderTypes";
+import { SelectOption } from "../../Dropdown/Dropdown";
+
+export const getOrderTypeSelectOptions = (t: TFunction): SelectOption[] => {
+  return [
+    {
+      value: OrderScopeType.public,
+      label: t("orders.anyone"),
+    },
+    {
+      value: OrderScopeType.private,
+      label: t("orders.someone"),
+    },
+  ];
+};

--- a/src/components/MakeWidget/helpers/index.ts
+++ b/src/components/MakeWidget/helpers/index.ts
@@ -11,7 +11,7 @@ export const getOrderTypeSelectOptions = (t: TFunction): SelectOption[] => {
     },
     {
       value: OrderScopeType.private,
-      label: t("orders.someone"),
+      label: t("orders.specificWallet"),
     },
   ];
 };

--- a/src/components/MakeWidget/subcomponents/AddressInput/AddressInput.styles.tsx
+++ b/src/components/MakeWidget/subcomponents/AddressInput/AddressInput.styles.tsx
@@ -1,15 +1,30 @@
 import styled from "styled-components/macro";
 
+import { InputTextStyle } from "../../../../style/mixins";
+import IconButton from "../../../IconButton/IconButton";
 import TextInput from "../../../TextInput/TextInput";
 import { StyledInput } from "../../../TextInput/TextInput.styles";
 
+export const Wrapper = styled.div`
+  position: relative;
+  background: ${({ theme }) =>
+    theme.name === "dark" ? theme.colors.darkGrey : theme.colors.primaryLight};
+`;
+
+export const StyledIconButton = styled(IconButton)`
+  position: absolute;
+  top: 0.825rem;
+  right: 1rem;
+`;
+
 export const Input = styled(TextInput)`
-  display: flex;
-  align-items: center;
-  flex-grow: 1;
-  height: 2.125rem;
+  height: 100%;
 
   ${StyledInput} {
+    ${InputTextStyle};
+
+    padding-right: 3.5rem;
+    height: 100%;
     font-size: 1rem;
     font-weight: 400;
   }

--- a/src/components/MakeWidget/subcomponents/AddressInput/AddressInput.styles.tsx
+++ b/src/components/MakeWidget/subcomponents/AddressInput/AddressInput.styles.tsx
@@ -13,8 +13,4 @@ export const Input = styled(TextInput)`
     font-size: 1rem;
     font-weight: 400;
   }
-
-  &:focus {
-    outline: 0;
-  }
 `;

--- a/src/components/MakeWidget/subcomponents/AddressInput/AddressInput.styles.tsx
+++ b/src/components/MakeWidget/subcomponents/AddressInput/AddressInput.styles.tsx
@@ -1,0 +1,20 @@
+import styled from "styled-components/macro";
+
+import TextInput from "../../../TextInput/TextInput";
+import { StyledInput } from "../../../TextInput/TextInput.styles";
+
+export const Input = styled(TextInput)`
+  display: flex;
+  align-items: center;
+  flex-grow: 1;
+  height: 2.125rem;
+
+  ${StyledInput} {
+    font-size: 1rem;
+    font-weight: 400;
+  }
+
+  &:focus {
+    outline: 0;
+  }
+`;

--- a/src/components/MakeWidget/subcomponents/AddressInput/AddressInput.tsx
+++ b/src/components/MakeWidget/subcomponents/AddressInput/AddressInput.tsx
@@ -1,0 +1,36 @@
+import React, { FC } from "react";
+import { useTranslation } from "react-i18next";
+
+import useAutoFocus from "../../../../hooks/useAutoFocus";
+import { Input } from "./AddressInput.styles";
+
+export type HTMLInputProps = JSX.IntrinsicElements["input"];
+
+interface AddressInputProps {
+  value: string;
+  onChange: (value: string) => void;
+}
+
+const AddressInput: FC<AddressInputProps> = ({ value, onChange }) => {
+  const { t } = useTranslation();
+  const inputRef = useAutoFocus();
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    onChange(e.target.value);
+  };
+
+  return (
+    <Input
+      autoFocus
+      hideLabel
+      label={t("orders.counterPartyAddress")}
+      inputRef={inputRef}
+      maxLength={42}
+      placeholder={t("orders.enterCounterPartyAddressOrENS")}
+      value={value}
+      onChange={handleChange}
+    />
+  );
+};
+
+export default AddressInput;

--- a/src/components/MakeWidget/subcomponents/AddressInput/AddressInput.tsx
+++ b/src/components/MakeWidget/subcomponents/AddressInput/AddressInput.tsx
@@ -2,16 +2,21 @@ import React, { FC } from "react";
 import { useTranslation } from "react-i18next";
 
 import useAutoFocus from "../../../../hooks/useAutoFocus";
-import { Input } from "./AddressInput.styles";
+import { Input, Wrapper, StyledIconButton } from "./AddressInput.styles";
 
 export type HTMLInputProps = JSX.IntrinsicElements["input"];
 
 interface AddressInputProps {
   value: string;
   onChange: (value: string) => void;
+  className?: string;
 }
 
-const AddressInput: FC<AddressInputProps> = ({ value, onChange }) => {
+const AddressInput: FC<AddressInputProps> = ({
+  value,
+  onChange,
+  className,
+}) => {
   const { t } = useTranslation();
   const inputRef = useAutoFocus();
 
@@ -20,16 +25,19 @@ const AddressInput: FC<AddressInputProps> = ({ value, onChange }) => {
   };
 
   return (
-    <Input
-      autoFocus
-      hideLabel
-      label={t("orders.counterPartyAddress")}
-      inputRef={inputRef}
-      maxLength={42}
-      placeholder={t("orders.enterCounterPartyAddressOrENS")}
-      value={value}
-      onChange={handleChange}
-    />
+    <Wrapper className={className}>
+      <Input
+        autoFocus
+        hideLabel
+        label={t("orders.counterPartyAddress")}
+        inputRef={inputRef}
+        maxLength={42}
+        placeholder={t("orders.enterCounterPartyAddressOrENS")}
+        value={value}
+        onChange={handleChange}
+      />
+      <StyledIconButton icon="information-circle-outline" />
+    </Wrapper>
   );
 };
 

--- a/src/components/MakeWidget/subcomponents/ExpirySelector/ExpirySelector.styles.tsx
+++ b/src/components/MakeWidget/subcomponents/ExpirySelector/ExpirySelector.styles.tsx
@@ -1,7 +1,7 @@
 import styled, { css } from "styled-components/macro";
 
 import { InputOrButtonBorderStyleType2 } from "../../../../style/mixins";
-import { Dropdown } from "../../../Dropdown/Dropdown";
+import Dropdown from "../../../Dropdown/Dropdown";
 import { SelectButtonText } from "../../../Dropdown/Dropdown.styles";
 
 export const SelectorStyle = css`
@@ -56,10 +56,4 @@ export const StyledDropdown = styled(Dropdown)`
   ${SelectButtonText} {
     max-width: 7rem;
   }
-`;
-
-export const Sizer = styled.div`
-  position: absolute;
-  pointer-events: none;
-  opacity: 0;
 `;

--- a/src/components/MakeWidget/subcomponents/ExpirySelector/ExpirySelector.tsx
+++ b/src/components/MakeWidget/subcomponents/ExpirySelector/ExpirySelector.tsx
@@ -1,8 +1,12 @@
 import React, { useState, useEffect, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 
+import {
+  SelectLabel,
+  SelectWrapper,
+} from "../../../../styled-components/Select/Select";
 import { SelectOption } from "../../../Dropdown/Dropdown";
-import { Wrapper, Title, Input, StyledDropdown } from "./ExpirySelector.styles";
+import { Input, StyledDropdown } from "./ExpirySelector.styles";
 import getExpirySelectOptions from "./helpers/getExpirySelectOptions";
 
 const floatRegExp = new RegExp("^([0-9])*$");
@@ -38,14 +42,14 @@ export const ExpirySelector: React.FC<ExpirySelectorProps> = ({ onChange }) => {
   }
 
   return (
-    <Wrapper>
-      <Title>{t("common.expiresIn")}</Title>
+    <SelectWrapper>
+      <SelectLabel>{t("common.expiresIn")}</SelectLabel>
       <Input maxLength={3} value={amount} onChange={handleAmountChange} />
       <StyledDropdown
         selectedOption={unit}
         options={translatedOptions}
         onChange={handleUnitChange}
       />
-    </Wrapper>
+    </SelectWrapper>
   );
 };

--- a/src/components/MakeWidget/subcomponents/InfoSection/InfoSection.styles.tsx
+++ b/src/components/MakeWidget/subcomponents/InfoSection/InfoSection.styles.tsx
@@ -1,6 +1,6 @@
 import styled from "styled-components/macro";
 
-import IconButton from "../IconButton/IconButton";
+import IconButton from "../../../IconButton/IconButton";
 
 export const Wrapper = styled.div`
   display: grid;

--- a/src/components/MakeWidget/subcomponents/InfoSection/InfoSection.tsx
+++ b/src/components/MakeWidget/subcomponents/InfoSection/InfoSection.tsx
@@ -3,17 +3,22 @@ import React, { FC, PropsWithChildren } from "react";
 import { Wrapper, StyledIconButton } from "./InfoSection.styles";
 
 interface InfoSectionProps {
+  onInfoButtonClick?: () => void;
   className?: string;
 }
 
 const InfoSection: FC<PropsWithChildren<InfoSectionProps>> = ({
   children,
+  onInfoButtonClick,
   className,
 }) => {
   return (
     <Wrapper className={className}>
       {children}
-      <StyledIconButton icon="information-circle-outline" />
+      <StyledIconButton
+        icon="information-circle-outline"
+        onClick={onInfoButtonClick}
+      />
     </Wrapper>
   );
 };

--- a/src/components/MakeWidget/subcomponents/OrderTypeSelector/OrderTypeSelector.tsx
+++ b/src/components/MakeWidget/subcomponents/OrderTypeSelector/OrderTypeSelector.tsx
@@ -24,7 +24,7 @@ const OrderTypeSelector: FC<OrderTypeSelectorProps> = ({
 
   return (
     <SelectWrapper className={className}>
-      <SelectLabel>{t("common.expiresIn")}</SelectLabel>
+      <SelectLabel>{t("common.for")}</SelectLabel>
       <Dropdown
         value={selectedOrderTypeOption}
         options={options}

--- a/src/components/MakeWidget/subcomponents/OrderTypeSelector/OrderTypeSelector.tsx
+++ b/src/components/MakeWidget/subcomponents/OrderTypeSelector/OrderTypeSelector.tsx
@@ -5,7 +5,7 @@ import {
   SelectLabel,
   SelectWrapper,
 } from "../../../../styled-components/Select/Select";
-import { Dropdown, SelectOption } from "../../../Dropdown/Dropdown";
+import Dropdown, { SelectOption } from "../../../Dropdown/Dropdown";
 
 export type OrderTypeSelectorProps = {
   options: SelectOption[];
@@ -26,7 +26,7 @@ const OrderTypeSelector: FC<OrderTypeSelectorProps> = ({
     <SelectWrapper className={className}>
       <SelectLabel>{t("common.for")}</SelectLabel>
       <Dropdown
-        value={selectedOrderTypeOption}
+        selectedOption={selectedOrderTypeOption}
         options={options}
         onChange={onChange}
       />

--- a/src/components/MakeWidget/subcomponents/OrderTypeSelector/OrderTypeSelector.tsx
+++ b/src/components/MakeWidget/subcomponents/OrderTypeSelector/OrderTypeSelector.tsx
@@ -4,8 +4,8 @@ import { useTranslation } from "react-i18next";
 import {
   SelectLabel,
   SelectWrapper,
-} from "../../styled-components/Select/Select";
-import { Dropdown, SelectOption } from "../Dropdown/Dropdown";
+} from "../../../../styled-components/Select/Select";
+import { Dropdown, SelectOption } from "../../../Dropdown/Dropdown";
 
 export type OrderTypeSelectorProps = {
   options: SelectOption[];

--- a/src/components/OrderTypeSelector/OrderTypeSelector.tsx
+++ b/src/components/OrderTypeSelector/OrderTypeSelector.tsx
@@ -1,0 +1,37 @@
+import React, { FC } from "react";
+import { useTranslation } from "react-i18next";
+
+import {
+  SelectLabel,
+  SelectWrapper,
+} from "../../styled-components/Select/Select";
+import { Dropdown, SelectOption } from "../Dropdown/Dropdown";
+
+export type OrderTypeSelectorProps = {
+  options: SelectOption[];
+  selectedOrderTypeOption: SelectOption;
+  onChange: (option: SelectOption) => void;
+  className?: string;
+};
+
+const OrderTypeSelector: FC<OrderTypeSelectorProps> = ({
+  options,
+  selectedOrderTypeOption,
+  className,
+  onChange,
+}) => {
+  const { t } = useTranslation();
+
+  return (
+    <SelectWrapper className={className}>
+      <SelectLabel>{t("common.expiresIn")}</SelectLabel>
+      <Dropdown
+        value={selectedOrderTypeOption}
+        options={options}
+        onChange={onChange}
+      />
+    </SelectWrapper>
+  );
+};
+
+export default OrderTypeSelector;

--- a/src/components/TextInput/TextInput.styles.tsx
+++ b/src/components/TextInput/TextInput.styles.tsx
@@ -12,7 +12,7 @@ type TextInputStyleProps = {
 
 type StyledInputProps = Pick<
   React.HTMLProps<HTMLInputElement>,
-  "type" | "disabled"
+  "type" | "disabled" | "autoFocus"
 >;
 
 export const StyledFormLabel = styled(FormLabel)``;

--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -30,13 +30,13 @@ const TextInput: FC<TextInputProps> = ({
     <StyledTextInput
       hasError={hasError}
       hideLabel={hideLabel}
-      aria-label={label}
       disabled={disabled}
       className={className}
     >
       <StyledFormLabel>{label}</StyledFormLabel>
       <StyledInput
         {...inputProps}
+        aria-label={label}
         disabled={disabled}
         ref={inputRef}
         type={type}

--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -1,4 +1,4 @@
-import React, { FC, ReactElement } from "react";
+import React, { FC, ReactElement, RefObject } from "react";
 
 import {
   StyledFormLabel,
@@ -13,6 +13,7 @@ export type TextInputProps = {
   type?: string;
   hasError?: boolean;
   hideLabel?: boolean;
+  inputRef?: RefObject<HTMLInputElement>;
 } & HTMLInputProps;
 
 const TextInput: FC<TextInputProps> = ({
@@ -22,6 +23,7 @@ const TextInput: FC<TextInputProps> = ({
   hasError,
   hideLabel,
   disabled,
+  inputRef,
   ...inputProps
 }): ReactElement => {
   return (
@@ -33,7 +35,12 @@ const TextInput: FC<TextInputProps> = ({
       className={className}
     >
       <StyledFormLabel>{label}</StyledFormLabel>
-      <StyledInput {...inputProps} disabled={disabled} type={type} />
+      <StyledInput
+        {...inputProps}
+        disabled={disabled}
+        ref={inputRef}
+        type={type}
+      />
     </StyledTextInput>
   );
 };

--- a/src/components/TokenList/TokenList.styles.tsx
+++ b/src/components/TokenList/TokenList.styles.tsx
@@ -2,7 +2,7 @@ import styled from "styled-components/macro";
 
 import isActiveLanguageLogographic from "../../helpers/isActiveLanguageLogographic";
 import breakPoints from "../../style/breakpoints";
-import { InputOrButtonBorderStyleType2 } from "../../style/mixins";
+import { InputTextStyle } from "../../style/mixins";
 import { sizes } from "../../style/sizes";
 import Icon from "../Icon/Icon";
 import { ScrollContainer } from "../Overlay/Overlay.styles";
@@ -55,22 +55,10 @@ export const SearchInput = styled(TextInput)`
   background-color: ${(props) => props.theme.colors.black};
 
   ${StyledInput} {
-    ${InputOrButtonBorderStyleType2};
+    ${InputTextStyle};
+
     border-radius: 2px;
-    line-height: 2.25;
-    padding: 0.25rem 0.625rem;
-    font-size: 1rem;
-    font-weight: 400;
     background: transparent;
-    color: ${(props) => props.theme.colors.white};
-
-    &::placeholder {
-      color: ${(props) => props.theme.colors.lightGrey};
-    }
-
-    &:focus {
-      border-color: ${(props) => props.theme.colors.primary};
-    }
   }
 `;
 

--- a/src/components/WidgetFrame/WidgetFrame.styles.tsx
+++ b/src/components/WidgetFrame/WidgetFrame.styles.tsx
@@ -3,7 +3,7 @@ import styled from "styled-components/macro";
 import breakPoints from "../../style/breakpoints";
 import { sizes } from "../../style/sizes";
 
-export const Container = styled.div`
+export const WidgetFrameWrapper = styled.div`
   display: flex;
   flex-direction: column;
   position: relative;
@@ -43,7 +43,7 @@ export const StyledWidgetFrame = styled.div<StyledTradeContainerProps>`
   height: 100%;
   min-height: ${sizes.widgetSize};
 
-  ${Container} {
+  ${WidgetFrameWrapper} {
     box-shadow: ${(props) =>
       props.$isConnected
         ? props.theme.shadows.widgetGlow

--- a/src/components/WidgetFrame/WidgetFrame.tsx
+++ b/src/components/WidgetFrame/WidgetFrame.tsx
@@ -1,6 +1,6 @@
 import React, { FC, ReactElement } from "react";
 
-import { Container, StyledWidgetFrame } from "./WidgetFrame.styles";
+import { WidgetFrameWrapper, StyledWidgetFrame } from "./WidgetFrame.styles";
 
 type WidgetFrameType = {
   children?: React.ReactNode;
@@ -15,7 +15,7 @@ const WidgetFrame: FC<WidgetFrameType> = ({
 }): ReactElement => {
   return (
     <StyledWidgetFrame $isOpen={isOpen} $isConnected={isConnected}>
-      <Container>{children}</Container>
+      <WidgetFrameWrapper>{children}</WidgetFrameWrapper>
     </StyledWidgetFrame>
   );
 };

--- a/src/hooks/useAutoFocus.ts
+++ b/src/hooks/useAutoFocus.ts
@@ -1,0 +1,16 @@
+import { useRef, useEffect } from "react";
+
+const useAutoFocus = () => {
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (inputRef.current) {
+      console.log(inputRef.current);
+      inputRef.current.focus();
+    }
+  }, []);
+
+  return inputRef;
+};
+
+export default useAutoFocus;

--- a/src/hooks/useAutoFocus.ts
+++ b/src/hooks/useAutoFocus.ts
@@ -5,7 +5,6 @@ const useAutoFocus = () => {
 
   useEffect(() => {
     if (inputRef.current) {
-      console.log(inputRef.current);
       inputRef.current.focus();
     }
   }, []);

--- a/src/pages/Make/Make.styles.tsx
+++ b/src/pages/Make/Make.styles.tsx
@@ -2,11 +2,12 @@ import styled from "styled-components/macro";
 
 import Page from "../../components/Page/Page";
 import { WidgetFrameWrapper } from "../../components/WidgetFrame/WidgetFrame.styles";
-import { sizes } from "../../style/sizes";
+import breakPoints from "../../style/breakpoints";
 
 export const StyledPage = styled(Page)`
   ${WidgetFrameWrapper} {
-    width: 100%;
-    max-width: ${sizes.mySwapsWidgetSize};
+    @media ${breakPoints.phoneOnly} {
+      height: 27rem;
+    }
   }
 `;

--- a/src/pages/Make/Make.tsx
+++ b/src/pages/Make/Make.tsx
@@ -1,13 +1,13 @@
 import React, { FC } from "react";
 
 import MakeWidget from "../../components/MakeWidget/MakeWidget";
-import Page from "../../components/Page/Page";
+import { StyledPage } from "./Make.styles";
 
 const MakePage: FC = () => {
   return (
-    <Page>
+    <StyledPage>
       <MakeWidget />
-    </Page>
+    </StyledPage>
   );
 };
 

--- a/src/style/mixins.ts
+++ b/src/style/mixins.ts
@@ -96,3 +96,9 @@ export const TextEllipsis = css`
   overflow: hidden;
   text-overflow: ellipsis;
 `;
+
+export const FlexAlignCenter = css`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;

--- a/src/style/mixins.ts
+++ b/src/style/mixins.ts
@@ -53,6 +53,24 @@ export const InputOrButtonBorderStyleType2 = css`
   }
 `;
 
+export const InputTextStyle = css`
+  ${InputOrButtonBorderStyleType2};
+
+  line-height: 2.25;
+  padding: 0.25rem 0.625rem;
+  font-size: 1rem;
+  font-weight: 400;
+  color: ${(props) => props.theme.colors.white};
+
+  &::placeholder {
+    color: ${(props) => props.theme.colors.lightGrey};
+  }
+
+  &:focus {
+    border-color: ${(props) => props.theme.colors.primary};
+  }
+`;
+
 export const BorderlessButtonStyle = css`
   border: 1px solid transparent;
 

--- a/src/styled-components/Select/Select.tsx
+++ b/src/styled-components/Select/Select.tsx
@@ -1,0 +1,38 @@
+import styled, { css } from "styled-components/macro";
+
+import { InputOrButtonBorderStyleType2 } from "../../style/mixins";
+
+export const SelectElementStyle = css`
+  ${InputOrButtonBorderStyleType2};
+
+  font-size: 0.75rem;
+  font-weight: 700;
+  margin-right: -1px;
+`;
+
+export const SelectWrapper = styled.div`
+  display: flex;
+  height: 2rem;
+  width: fit-content;
+  color: ${({ theme }) =>
+    theme.name === "dark" ? theme.colors.white : theme.colors.primary};
+`;
+
+export const SelectLabel = styled.div`
+  ${SelectElementStyle};
+
+  display: flex;
+  align-items: center;
+  border-top-left-radius: 1rem;
+  border-bottom-left-radius: 1rem;
+  padding: 0 0.75rem;
+  color: ${({ theme }) => theme.colors.lightGrey};
+  text-transform: uppercase;
+
+  &:hover,
+  :active,
+  :focus {
+    border: 1px solid ${({ theme }) => theme.colors.borderGrey};
+    cursor: initial;
+  }
+`;

--- a/src/styled-components/WidgetHeader/WidgetHeader.tsx
+++ b/src/styled-components/WidgetHeader/WidgetHeader.tsx
@@ -6,7 +6,7 @@ export const WidgetHeader = styled.div`
   display: flex;
   justify-content: space-between;
   min-height: 2rem;
-  margin-bottom: 2rem;
+  margin-bottom: 1.875rem;
   width: 100%;
 
   @media ${breakPoints.phoneOnly} {

--- a/src/types/orderTypes.ts
+++ b/src/types/orderTypes.ts
@@ -1,0 +1,10 @@
+export enum OrderType {
+  publicListed = "public-listed",
+  publicUnlisted = "public-unlisted",
+  private = "private",
+}
+
+export enum OrderScopeType {
+  public = "public",
+  private = "private",
+}


### PR DESCRIPTION
Fixes #558 
Fixes #585 

New components:
- SwapTypeSelector
- Checkbox

Note to self, add translations:

```
    Common:
    "for": "For"

    Orders:
    "moreInformation": "More information",
    "publiclyList": "Publicly list",
    "publiclyListDescription": "Allow others to publicly find my swap",
    "anyone": "Anyone",
    "someone": "Someone",
    "counterPartyAddress": "Counterpary address",
    "enterCounterPartyAddressOrENS": "Enter counterparty address or ENS"
```