### PR TITLE
Feature/605 maker error handling

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -173,7 +173,7 @@
     "nonce_already_used": "Nonce has been already used or cancelled",
     "unableSwap": "Unable to swap",
     "unpredictable_gas_limit": "The gas limit is unpredictable",
-    "swapFail": "The swap would fail for the following reasons.",
+    "swapFail": "The swap would fail for the following reasons:",
     "invalidAddress": "{{address}} is an invalid address",
     "invalidValue": "{{address}} is an invalid value",
     "unknownError": "Unknown error"

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -173,7 +173,10 @@
     "nonce_already_used": "Nonce has been already used or cancelled",
     "unableSwap": "Unable to swap",
     "unpredictable_gas_limit": "The gas limit is unpredictable",
-    "swapFail": "The swap would fail for the following reasons."
+    "swapFail": "The swap would fail for the following reasons.",
+    "invalidAddress": "{{address}} is an invalid address",
+    "invalidValue": "{{address}} is an invalid value",
+    "unknownError": "Unknown error"
   },
   "wallet": {
     "connectWallet": "Connect Wallet",

--- a/src/components/ErrorList/ErrorList.tsx
+++ b/src/components/ErrorList/ErrorList.tsx
@@ -1,6 +1,7 @@
+import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 
-import type { ErrorType } from "../../constants/errors";
+import { AppError } from "../../errors/appError";
 import { OverlayActionButton } from "../Overlay/Overlay.styles";
 import {
   Container,
@@ -8,27 +9,40 @@ import {
   LegendDivider,
   StyledScrollContainer,
 } from "./ErrorList.styles";
+import { getAppErrorTranslation } from "./helpers";
 import ErrorListItem from "./subcomponents/ErrorListItem/ErrorListItem";
 
 type ErrorListProps = {
-  errors: ErrorType[];
-  handleClick: () => void;
+  errors: AppError[];
+  onBackButtonClick: () => void;
 };
 
-export const ErrorList = ({ errors = [], handleClick }: ErrorListProps) => {
+export const ErrorList = ({
+  errors = [],
+  onBackButtonClick,
+}: ErrorListProps) => {
   const { t } = useTranslation();
+
+  const errorListItems = useMemo(
+    () => errors.map((error) => getAppErrorTranslation(error)),
+    [errors]
+  );
 
   return (
     <Container>
       <LegendDivider />
       <StyledScrollContainer>
         <StyledErrorList>
-          {errors.map((error) => {
-            return <ErrorListItem key={error} error={error} />;
-          })}
+          {errorListItems.map((error) => (
+            <ErrorListItem
+              key={error.title}
+              title={error.title}
+              text={error.text}
+            />
+          ))}
         </StyledErrorList>
       </StyledScrollContainer>
-      <OverlayActionButton onClick={handleClick}>
+      <OverlayActionButton onClick={onBackButtonClick}>
         {t("common.back")}
       </OverlayActionButton>
     </Container>

--- a/src/components/ErrorList/helpers/index.ts
+++ b/src/components/ErrorList/helpers/index.ts
@@ -1,0 +1,34 @@
+import i18n from "i18next";
+
+import { AppError, AppErrorType } from "../../../errors/appError";
+import { ErrorListItemProps } from "../subcomponents/ErrorListItem/ErrorListItem";
+
+export const getAppErrorTranslation = (error: AppError): ErrorListItemProps => {
+  if (error.type === AppErrorType.invalidAddress) {
+    return {
+      title: AppErrorType.invalidAddress,
+      text: i18n.t("validatorErrors.invalidAddress", {
+        address: error.argument,
+      }),
+    };
+  }
+
+  if (error.type === AppErrorType.invalidValue) {
+    return {
+      title: AppErrorType.invalidValue,
+      text: i18n.t("validatorErrors.invalidValue", { address: error.argument }),
+    };
+  }
+
+  if (error.type === AppErrorType.unauthorized) {
+    return {
+      title: AppErrorType.unauthorized,
+      text: i18n.t("validatorErrors.unauthorized"),
+    };
+  }
+
+  return {
+    title: AppErrorType.unknownError,
+    text: i18n.t("validatorErrors.unknownError"),
+  };
+};

--- a/src/components/ErrorList/subcomponents/ErrorListItem/ErrorListItem.styles.tsx
+++ b/src/components/ErrorList/subcomponents/ErrorListItem/ErrorListItem.styles.tsx
@@ -20,6 +20,9 @@ export const ErrorTextContainer = styled.div`
 
 export const StyledErrorIcon = styled(Icon)`
   margin-right: 1.125rem;
+
+  color: ${({ theme }) =>
+    theme.name === "dark" ? theme.colors.white : theme.colors.primary};
 `;
 
 export const StyledSubText = styled(SubText)`

--- a/src/components/ErrorList/subcomponents/ErrorListItem/ErrorListItem.tsx
+++ b/src/components/ErrorList/subcomponents/ErrorListItem/ErrorListItem.tsx
@@ -1,14 +1,5 @@
-import React, { FC, useMemo } from "react";
-import { useTranslation } from "react-i18next";
+import React, { FC } from "react";
 
-import { getMessageFromCode } from "eth-rpc-errors";
-
-import {
-  swapErrorList,
-  swapErrorTranslationMap,
-  ErrorType,
-  ErrorCodesMap,
-} from "../../../../constants/errors";
 import { InfoHeading } from "../../../Typography/Typography";
 import {
   ErrorTextContainer,
@@ -18,32 +9,17 @@ import {
 } from "./ErrorListItem.styles";
 
 export interface ErrorListItemProps {
-  error: ErrorType;
+  title: string;
+  text?: string;
 }
 
-const ErrorListItem: FC<ErrorListItemProps> = ({ error }) => {
-  const { t } = useTranslation();
-
-  const translation = useMemo(() => {
-    const airswapProviderError = swapErrorList.find((a) => a === error);
-
-    // Translations for contract errors are in the translation file
-    if (airswapProviderError) {
-      return t(
-        `validatorErrors.${swapErrorTranslationMap[airswapProviderError]}`
-      );
-    }
-
-    // Translations for ethereum rpc and provider errors are sourced from the eth-rpc-errors library
-    return getMessageFromCode(ErrorCodesMap[error], t("common.undefined"));
-  }, [error]); // eslint-disable-line react-hooks/exhaustive-deps
-
+const ErrorListItem: FC<ErrorListItemProps> = ({ title, text }) => {
   return (
     <Container>
       <StyledErrorIcon name="information-circle-outline" iconSize={1.5} />
       <ErrorTextContainer>
-        <InfoHeading>{error}</InfoHeading>
-        <StyledSubText>{translation}</StyledSubText>
+        <InfoHeading>{title}</InfoHeading>
+        {text && <StyledSubText>{text}</StyledSubText>}
       </ErrorTextContainer>
     </Container>
   );

--- a/src/components/MakeWidget/MakeWidget.tsx
+++ b/src/components/MakeWidget/MakeWidget.tsx
@@ -71,8 +71,7 @@ const MakeWidget: FC = () => {
   const allTokens = useAppSelector(selectAllTokenInfo);
   const supportedTokens = useAppSelector(selectAllSupportedTokens);
   const userTokens = useAppSelector(selectUserTokens);
-  const { status, errors, lastUserOrder } =
-    useAppSelector(selectMakeOtcReducer);
+  const { status, error, lastUserOrder } = useAppSelector(selectMakeOtcReducer);
   const {
     active,
     chainId,
@@ -311,10 +310,10 @@ const MakeWidget: FC = () => {
         onCloseButtonClick={() =>
           handleActionButtonClick(ButtonActions.restart)
         }
-        isHidden={!errors.length}
+        isHidden={!error}
       >
         <ErrorList
-          errors={errors}
+          errors={[]}
           handleClick={() => handleActionButtonClick(ButtonActions.restart)}
         />
       </Overlay>

--- a/src/components/MakeWidget/MakeWidget.tsx
+++ b/src/components/MakeWidget/MakeWidget.tsx
@@ -175,7 +175,7 @@ const MakeWidget: FC = () => {
           senderToken: takerTokenInfo?.address!,
           senderAmount: toAtomicString(takerAmount, takerTokenInfo?.decimals!),
           chainId: chainId!,
-          library: library,
+          library: library!,
         })
       );
     }

--- a/src/components/MakeWidget/MakeWidget.tsx
+++ b/src/components/MakeWidget/MakeWidget.tsx
@@ -313,8 +313,10 @@ const MakeWidget: FC = () => {
         isHidden={!error}
       >
         <ErrorList
-          errors={[]}
-          handleClick={() => handleActionButtonClick(ButtonActions.restart)}
+          errors={error ? [error] : []}
+          onBackButtonClick={() =>
+            handleActionButtonClick(ButtonActions.restart)
+          }
         />
       </Overlay>
     </Container>

--- a/src/components/OrderDetailWidget/subcomponents/OrderRecipientInfo/OrderRecipientInfo.tsx
+++ b/src/components/OrderDetailWidget/subcomponents/OrderRecipientInfo/OrderRecipientInfo.tsx
@@ -1,7 +1,8 @@
-import React, { FC, useState } from "react";
+import React, { FC, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import writeAddressToClipboard from "../../../../helpers/writeAddressToClipboard";
+import useEnsAddress from "../../../../hooks/useEnsAddress";
 import { OrderType } from "../../../../types/orderTypes";
 import {
   Button,
@@ -30,24 +31,28 @@ const OrderRecipientInfo: FC<OrderRecipientInfoProps> = ({
   const [writeAddressToClipboardSuccess, setWriteAddressToClipboardSuccess] =
     useState(false);
 
+  const recipientEnsAddress = useEnsAddress(recipientAddress);
+  const readableAddress = recipientEnsAddress || recipientAddress;
+
   const handleClick = async () => {
-    if (recipientAddress === "address") {
+    if (readableAddress) {
       setWriteAddressToClipboardSuccess(
-        await writeAddressToClipboard(recipientAddress)
+        await writeAddressToClipboard(readableAddress)
       );
     }
   };
 
   if (
     recipientAddress &&
+    readableAddress &&
     recipientAddress !== userAddress &&
     orderType === OrderType.private
   ) {
     return (
       <Button onClick={handleClick} className={className}>
         <For>{`${t("common.for")}:`}</For>
-        {`${recipientAddress.substr(0, 3)}...${recipientAddress.substr(
-          recipientAddress.length - 3,
+        {`${readableAddress.substr(0, 3)}...${readableAddress.substr(
+          readableAddress.length - 3,
           3
         )}`}
         <StyledCopyIcon

--- a/src/components/OrderDetailWidget/subcomponents/OrderRecipientInfo/OrderRecipientInfo.tsx
+++ b/src/components/OrderDetailWidget/subcomponents/OrderRecipientInfo/OrderRecipientInfo.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useMemo, useState } from "react";
+import React, { FC, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import writeAddressToClipboard from "../../../../helpers/writeAddressToClipboard";

--- a/src/components/SwapWidget/SwapWidget.tsx
+++ b/src/components/SwapWidget/SwapWidget.tsx
@@ -78,7 +78,6 @@ import useTokenAddress from "../../hooks/useTokenAddress";
 import useTokenInfo from "../../hooks/useTokenInfo";
 import { AppRoutes } from "../../routes";
 import { TokenSelectModalTypes } from "../../types/tokenSelectModalTypes";
-import { ErrorList } from "../ErrorList/ErrorList";
 import GasFreeSwapsModal from "../InformationModals/subcomponents/GasFreeSwapsModal/GasFreeSwapsModal";
 import ProtocolFeeDiscountModal from "../InformationModals/subcomponents/ProtocolFeeDiscountModal/ProtocolFeeDiscountModal";
 import Overlay from "../Overlay/Overlay";
@@ -94,6 +93,7 @@ import getTokenPairs from "./helpers/getTokenPairs";
 import ActionButtons, {
   ButtonActions,
 } from "./subcomponents/ActionButtons/ActionButtons";
+import { ErrorList } from "./subcomponents/ErrorList/ErrorList";
 import InfoSection from "./subcomponents/InfoSection/InfoSection";
 import SwapWidgetHeader from "./subcomponents/SwapWidgetHeader/SwapWidgetHeader";
 

--- a/src/components/SwapWidget/subcomponents/ErrorList/ErrorList.styles.tsx
+++ b/src/components/SwapWidget/subcomponents/ErrorList/ErrorList.styles.tsx
@@ -1,0 +1,33 @@
+import styled from "styled-components/macro";
+
+import { sizes } from "../../../../style/sizes";
+import { ScrollContainer } from "../../../Overlay/Overlay.styles";
+
+export const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  padding: 0 ${sizes.tradeContainerPadding} ${sizes.tradeContainerPadding};
+`;
+
+export const StyledScrollContainer = styled(ScrollContainer)`
+  max-height: calc(100% - 3.125rem);
+  overflow-y: ${(props) => (props.$overflow ? "scroll" : "hidden")};
+`;
+
+export const StyledErrorList = styled.div`
+  display: flex;
+  flex-direction: column;
+  background: ${(props) => props.theme.colors.black};
+`;
+
+export const LegendDivider = styled.div`
+  width: calc(100% - 4rem);
+  height: 1px;
+  background: ${(props) => props.theme.colors.borderGrey};
+  align-self: center;
+`;

--- a/src/components/SwapWidget/subcomponents/ErrorList/ErrorList.tsx
+++ b/src/components/SwapWidget/subcomponents/ErrorList/ErrorList.tsx
@@ -1,0 +1,36 @@
+import { useTranslation } from "react-i18next";
+
+import type { ErrorType } from "../../../../constants/errors";
+import { OverlayActionButton } from "../../../Overlay/Overlay.styles";
+import {
+  Container,
+  StyledErrorList,
+  LegendDivider,
+  StyledScrollContainer,
+} from "./ErrorList.styles";
+import ErrorListItem from "./subcomponents/ErrorListItem/ErrorListItem";
+
+type ErrorListProps = {
+  errors: ErrorType[];
+  handleClick: () => void;
+};
+
+export const ErrorList = ({ errors = [], handleClick }: ErrorListProps) => {
+  const { t } = useTranslation();
+
+  return (
+    <Container>
+      <LegendDivider />
+      <StyledScrollContainer>
+        <StyledErrorList>
+          {errors.map((error) => {
+            return <ErrorListItem key={error} error={error} />;
+          })}
+        </StyledErrorList>
+      </StyledScrollContainer>
+      <OverlayActionButton onClick={handleClick}>
+        {t("common.back")}
+      </OverlayActionButton>
+    </Container>
+  );
+};

--- a/src/components/SwapWidget/subcomponents/ErrorList/subcomponents/ErrorListItem/ErrorListItem.styles.tsx
+++ b/src/components/SwapWidget/subcomponents/ErrorList/subcomponents/ErrorListItem/ErrorListItem.styles.tsx
@@ -1,0 +1,27 @@
+import styled from "styled-components/macro";
+
+import Icon from "../../../../../Icon/Icon";
+import { SubText } from "../../../../../Typography/Typography";
+
+export const Container = styled.div`
+  display: flex;
+  align-items: center;
+  width: 100%;
+  height: 3rem;
+  margin-top: 1.5rem;
+`;
+
+export const ErrorTextContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  width: calc(100% - 3.75rem);
+`;
+
+export const StyledErrorIcon = styled(Icon)`
+  margin-right: 1.125rem;
+`;
+
+export const StyledSubText = styled(SubText)`
+  color: ${(props) => props.theme.colors.lightGrey};
+`;

--- a/src/components/SwapWidget/subcomponents/ErrorList/subcomponents/ErrorListItem/ErrorListItem.styles.tsx
+++ b/src/components/SwapWidget/subcomponents/ErrorList/subcomponents/ErrorListItem/ErrorListItem.styles.tsx
@@ -20,6 +20,9 @@ export const ErrorTextContainer = styled.div`
 
 export const StyledErrorIcon = styled(Icon)`
   margin-right: 1.125rem;
+
+  color: ${({ theme }) =>
+    theme.name === "dark" ? theme.colors.white : theme.colors.primary};
 `;
 
 export const StyledSubText = styled(SubText)`

--- a/src/components/SwapWidget/subcomponents/ErrorList/subcomponents/ErrorListItem/ErrorListItem.tsx
+++ b/src/components/SwapWidget/subcomponents/ErrorList/subcomponents/ErrorListItem/ErrorListItem.tsx
@@ -1,0 +1,52 @@
+import React, { FC, useMemo } from "react";
+import { useTranslation } from "react-i18next";
+
+import { getMessageFromCode } from "eth-rpc-errors";
+
+import {
+  swapErrorList,
+  swapErrorTranslationMap,
+  ErrorType,
+  ErrorCodesMap,
+} from "../../../../../../constants/errors";
+import { InfoHeading } from "../../../../../Typography/Typography";
+import {
+  ErrorTextContainer,
+  Container,
+  StyledErrorIcon,
+  StyledSubText,
+} from "./ErrorListItem.styles";
+
+export interface ErrorListItemProps {
+  error: ErrorType;
+}
+
+const ErrorListItem: FC<ErrorListItemProps> = ({ error }) => {
+  const { t } = useTranslation();
+
+  const translation = useMemo(() => {
+    const airswapProviderError = swapErrorList.find((a) => a === error);
+
+    // Translations for contract errors are in the translation file
+    if (airswapProviderError) {
+      return t(
+        `validatorErrors.${swapErrorTranslationMap[airswapProviderError]}`
+      );
+    }
+
+    // Translations for ethereum rpc and provider errors are sourced from the eth-rpc-errors library
+    return getMessageFromCode(ErrorCodesMap[error], t("common.undefined"));
+  }, [error]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  return (
+    <Container>
+      <StyledErrorIcon name="information-circle-outline" iconSize={1.5} />
+      <ErrorTextContainer>
+        <InfoHeading>{error}</InfoHeading>
+        <StyledSubText>{translation}</StyledSubText>
+      </ErrorTextContainer>
+    </Container>
+  );
+};
+
+export default ErrorListItem;

--- a/src/components/Toasts/ToastController.tsx
+++ b/src/components/Toasts/ToastController.tsx
@@ -3,6 +3,8 @@ import toast from "react-hot-toast";
 import { findTokenByAddress } from "@airswap/metadata";
 import { TokenInfo } from "@airswap/typescript";
 
+import i18n from "i18next";
+
 import {
   SubmittedApproval,
   SubmittedTransaction,
@@ -94,4 +96,11 @@ export const notifyError = (props: { heading: string; cta: string }) => {
       duration: 3000,
     }
   );
+};
+
+export const notifyRejectedByUserError = () => {
+  notifyError({
+    heading: i18n.t("orders.swapFailed"),
+    cta: i18n.t("orders.swapRejectedByUser"),
+  });
 };

--- a/src/errors/appError.ts
+++ b/src/errors/appError.ts
@@ -1,9 +1,12 @@
 export enum AppErrorType {
+  chainDisconnected = "chain-disconnected",
+  disconnected = "disconnected",
   invalidAddress = "invalid-address",
   invalidValue = "invalid-value",
   rejectedByUser = "rejected-by-user",
   unauthorized = "unauthorized",
   unknownError = "unknown-error",
+  unsupportedMethod = "unsupported-method",
 }
 
 export type AppError = {

--- a/src/errors/appError.ts
+++ b/src/errors/appError.ts
@@ -11,7 +11,6 @@ export enum AppErrorType {
 
 export type AppError = {
   argument?: string;
-  error: unknown;
   type: AppErrorType;
 };
 
@@ -26,12 +25,10 @@ export const isAppError = (x: any): x is AppError => {
 
 export function transformToAppError(
   type: AppErrorType,
-  error: unknown,
   argument?: string
 ): AppError {
   return {
     argument,
-    error,
     type,
   };
 }

--- a/src/errors/ethSigUtilError.ts
+++ b/src/errors/ethSigUtilError.ts
@@ -1,0 +1,33 @@
+import { AppError, AppErrorType, transformToAppError } from "./appError";
+
+// Error from eth-sig-util I think. Not totally sure. Might rename this later
+
+interface EthSigUtilError {
+  argument: string;
+  value: string;
+  code: "INVALID_ARGUMENT";
+}
+
+export const isEthSigUtilError = (error: any): error is EthSigUtilError => {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "argument" in error &&
+    "value" in error &&
+    "code" in error
+  );
+};
+
+export const transformEthSigUtilErrorToAppError = (
+  error: EthSigUtilError
+): AppError => {
+  if (error.argument === "address") {
+    return transformToAppError(AppErrorType.invalidAddress, error, error.value);
+  }
+
+  if (error.argument === "value") {
+    return transformToAppError(AppErrorType.invalidValue, error, error.value);
+  }
+
+  return transformToAppError(AppErrorType.unknownError, error);
+};

--- a/src/errors/ethSigUtilError.ts
+++ b/src/errors/ethSigUtilError.ts
@@ -22,12 +22,12 @@ export const transformEthSigUtilErrorToAppError = (
   error: EthSigUtilError
 ): AppError => {
   if (error.argument === "address") {
-    return transformToAppError(AppErrorType.invalidAddress, error, error.value);
+    return transformToAppError(AppErrorType.invalidAddress, error.value);
   }
 
   if (error.argument === "value") {
-    return transformToAppError(AppErrorType.invalidValue, error, error.value);
+    return transformToAppError(AppErrorType.invalidValue, error.value);
   }
 
-  return transformToAppError(AppErrorType.unknownError, error);
+  return transformToAppError(AppErrorType.unknownError);
 };

--- a/src/errors/ethersProjectError.ts
+++ b/src/errors/ethersProjectError.ts
@@ -15,7 +15,9 @@ interface EthersProjectError {
   code: "INVALID_ARGUMENT";
 }
 
-export const ethersProjectError = (error: any): error is EthersProjectError => {
+export const isEthersProjectError = (
+  error: any
+): error is EthersProjectError => {
   return (
     typeof error === "object" &&
     error !== null &&

--- a/src/errors/ethersProjectError.ts
+++ b/src/errors/ethersProjectError.ts
@@ -1,14 +1,21 @@
 import { AppError, AppErrorType, transformToAppError } from "./appError";
 
-// Error from eth-sig-util I think. Not totally sure. Might rename this later
+// @ethersproject's logger throws errors like this:
 
-interface EthSigUtilError {
+// throwArgumentError(message: string, name: string, value: any): never {
+//   return this.throwError(message, Logger.errors.INVALID_ARGUMENT, {
+//     argument: name,
+//     value: value
+//   });
+// }
+
+interface EthersProjectError {
   argument: string;
   value: string;
   code: "INVALID_ARGUMENT";
 }
 
-export const isEthSigUtilError = (error: any): error is EthSigUtilError => {
+export const ethersProjectError = (error: any): error is EthersProjectError => {
   return (
     typeof error === "object" &&
     error !== null &&
@@ -18,8 +25,8 @@ export const isEthSigUtilError = (error: any): error is EthSigUtilError => {
   );
 };
 
-export const transformEthSigUtilErrorToAppError = (
-  error: EthSigUtilError
+export const transformEthersProjectErrorToAppError = (
+  error: EthersProjectError
 ): AppError => {
   if (error.argument === "address") {
     return transformToAppError(AppErrorType.invalidAddress, error.value);

--- a/src/errors/rpcError.ts
+++ b/src/errors/rpcError.ts
@@ -1,9 +1,14 @@
 import { errorCodes } from "eth-rpc-errors";
 
-import { ErrorWithCode } from "../constants/errors";
 import { AppError, AppErrorType, transformToAppError } from "./appError";
 
-export const isRpcError = (error: any): error is ErrorWithCode => {
+interface RpcError {
+  code: number;
+  message: string;
+  stack: string;
+}
+
+export const isRpcError = (error: any): error is RpcError => {
   return (
     typeof error === "object" &&
     error !== null &&
@@ -14,26 +19,26 @@ export const isRpcError = (error: any): error is ErrorWithCode => {
   );
 };
 
-export const transformRpcErrorToAppError = (error: ErrorWithCode): AppError => {
+export const transformRpcErrorToAppError = (error: RpcError): AppError => {
   if (error.code === 4001) {
-    return transformToAppError(AppErrorType.rejectedByUser, error);
+    return transformToAppError(AppErrorType.rejectedByUser);
   }
 
   if (error.code === 4100) {
-    return transformToAppError(AppErrorType.unauthorized, error);
+    return transformToAppError(AppErrorType.unauthorized);
   }
 
   if (error.code === 4200) {
-    return transformToAppError(AppErrorType.unsupportedMethod, error);
+    return transformToAppError(AppErrorType.unsupportedMethod);
   }
 
   if (error.code === 4900) {
-    return transformToAppError(AppErrorType.disconnected, error);
+    return transformToAppError(AppErrorType.disconnected);
   }
 
   if (error.code === 4901) {
-    return transformToAppError(AppErrorType.chainDisconnected, error);
+    return transformToAppError(AppErrorType.chainDisconnected);
   }
 
-  return transformToAppError(AppErrorType.unknownError, error);
+  return transformToAppError(AppErrorType.unknownError);
 };

--- a/src/errors/rpcError.ts
+++ b/src/errors/rpcError.ts
@@ -1,0 +1,39 @@
+import { errorCodes } from "eth-rpc-errors";
+
+import { ErrorWithCode } from "../constants/errors";
+import { AppError, AppErrorType, transformToAppError } from "./appError";
+
+export const isRpcError = (error: any): error is ErrorWithCode => {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    Object.values({ ...errorCodes.rpc, ...errorCodes.provider }).includes(
+      error.code
+    )
+  );
+};
+
+export const transformRpcErrorToAppError = (error: ErrorWithCode): AppError => {
+  if (error.code === 4001) {
+    return transformToAppError(AppErrorType.rejectedByUser, error);
+  }
+
+  if (error.code === 4100) {
+    return transformToAppError(AppErrorType.unauthorized, error);
+  }
+
+  if (error.code === 4200) {
+    return transformToAppError(AppErrorType.unsupportedMethod, error);
+  }
+
+  if (error.code === 4900) {
+    return transformToAppError(AppErrorType.disconnected, error);
+  }
+
+  if (error.code === 4901) {
+    return transformToAppError(AppErrorType.chainDisconnected, error);
+  }
+
+  return transformToAppError(AppErrorType.unknownError, error);
+};

--- a/src/features/makeOtc/makeOtcActions.ts
+++ b/src/features/makeOtc/makeOtcActions.ts
@@ -5,7 +5,7 @@ import { createOrder } from "@airswap/utils";
 import { createAsyncThunk } from "@reduxjs/toolkit";
 
 import { notifyRejectedByUserError } from "../../components/Toasts/ToastController";
-import { AppErrorType, isAppError } from "../../errors/appError";
+import {AppErrorType, isAppError} from "../../errors/appError";
 import { createSwapSignature } from "../../helpers/createSwapSignature";
 import { setError, setStatus, setUserOrder } from "./makeOtcSlice";
 
@@ -20,44 +20,50 @@ export const createOtcOrder = createAsyncThunk(
   ) => {
     dispatch(setStatus("signing"));
 
-    const unsignedOrder = createOrder({
-      expiry: params.expiry,
-      nonce: Date.now().toString(),
-      senderWallet: params.senderWallet,
-      signerWallet: params.signerWallet,
-      signerToken: params.signerToken,
-      senderToken: params.senderToken,
-      protocolFee: "7",
-      signerAmount: params.signerAmount,
-      senderAmount: params.senderAmount,
-      chainId: params.chainId,
-    });
+    try {
+      const unsignedOrder = createOrder({
+        expiry: params.expiry,
+        nonce: Date.now().toString(),
+        senderWallet: params.senderWallet,
+        signerWallet: params.signerWallet,
+        signerToken: params.signerToken,
+        senderToken: params.senderToken,
+        protocolFee: "7",
+        signerAmount: params.signerAmount,
+        senderAmount: params.senderAmount,
+        chainId: params.chainId,
+      });
 
-    const signature = await createSwapSignature(
-      unsignedOrder,
-      params.library.getSigner(),
-      swapDeploys[params.chainId],
-      params.chainId
-    );
+      const signature = await createSwapSignature(
+        unsignedOrder,
+        params.library.getSigner(),
+        swapDeploys[params.chainId],
+        params.chainId
+      );
 
-    if (isAppError(signature)) {
-      if (signature.type === AppErrorType.rejectedByUser) {
-        dispatch(setStatus("idle"));
-        notifyRejectedByUserError();
-      } else {
-        dispatch(setStatus("failed"));
-        dispatch(setError(signature));
+      if (isAppError(signature)) {
+        if (signature.type === AppErrorType.rejectedByUser) {
+          dispatch(setStatus("idle"));
+          notifyRejectedByUserError();
+        } else {
+          dispatch(setStatus("failed"));
+          dispatch(setError(signature));
+        }
+        return;
       }
-      return;
+
+      const fullOrder: FullOrder = {
+        ...unsignedOrder,
+        ...signature,
+        chainId: params.chainId.toString(),
+        swapContract: swapDeploys[params.chainId],
+      };
+
+      dispatch(setUserOrder(fullOrder));
+    } catch (error) {
+      console.log(error);
+      dispatch(setStatus("failed"));
+      dispatch(setError({ type: AppErrorType.unknownError }));
     }
-
-    const fullOrder: FullOrder = {
-      ...unsignedOrder,
-      ...signature,
-      chainId: params.chainId.toString(),
-      swapContract: swapDeploys[params.chainId],
-    };
-
-    dispatch(setUserOrder(fullOrder));
   }
 );

--- a/src/features/makeOtc/makeOtcActions.ts
+++ b/src/features/makeOtc/makeOtcActions.ts
@@ -1,13 +1,15 @@
 // @ts-ignore
 import * as swapDeploys from "@airswap/swap/deploys.js";
 import { FullOrder, UnsignedOrder } from "@airswap/typescript";
-import { createOrder, createSwapSignature } from "@airswap/utils";
+import { createOrder } from "@airswap/utils";
 import { createAsyncThunk } from "@reduxjs/toolkit";
 
 import i18n from "i18next";
 
 import { notifyError } from "../../components/Toasts/ToastController";
-import { setErrors, setStatus, setUserOrder } from "./makeOtcSlice";
+import { createSwapSignature } from "../../helpers/createSwapSignature";
+import { AppErrorType, isAppError } from "../../types/appError";
+import { setError, setStatus, setUserOrder } from "./makeOtcSlice";
 
 export const createOtcOrder = createAsyncThunk(
   "make-otc/createOtcOrder",
@@ -20,46 +22,46 @@ export const createOtcOrder = createAsyncThunk(
   ) => {
     dispatch(setStatus("signing"));
 
-    try {
-      const unsignedOrder = createOrder({
-        expiry: params.expiry,
-        nonce: Date.now().toString(),
-        senderWallet: params.senderWallet,
-        signerWallet: params.signerWallet,
-        signerToken: params.signerToken,
-        senderToken: params.senderToken,
-        protocolFee: "7",
-        signerAmount: params.signerAmount,
-        senderAmount: params.senderAmount,
-        chainId: params.chainId,
-      });
+    const unsignedOrder = createOrder({
+      expiry: params.expiry,
+      nonce: Date.now().toString(),
+      senderWallet: params.senderWallet,
+      signerWallet: params.signerWallet,
+      signerToken: params.signerToken,
+      senderToken: params.senderToken,
+      protocolFee: "7",
+      signerAmount: params.signerAmount,
+      senderAmount: params.senderAmount,
+      chainId: params.chainId,
+    });
 
-      const signature = await createSwapSignature(
-        unsignedOrder,
-        params.library.getSigner(),
-        swapDeploys[params.chainId],
-        params.chainId
-      );
+    const signature = await createSwapSignature(
+      unsignedOrder,
+      params.library.getSigner(),
+      swapDeploys[params.chainId],
+      params.chainId
+    );
 
-      const fullOrder: FullOrder = {
-        ...unsignedOrder,
-        ...signature,
-        chainId: params.chainId.toString(),
-        swapContract: swapDeploys[params.chainId],
-      };
-
-      dispatch(setUserOrder(fullOrder));
-    } catch (e: any) {
-      dispatch(setStatus("failed"));
-
-      if (e.code !== 4001) {
-        dispatch(setErrors(["invalidInput"]));
-      } else {
+    if (isAppError(signature)) {
+      if (signature.type === AppErrorType.rejectedByUser) {
         notifyError({
           heading: i18n.t("orders.swapFailed"),
           cta: i18n.t("orders.swapRejectedByUser"),
         });
+      } else {
+        dispatch(setStatus("failed"));
+        dispatch(setError(signature));
       }
+      return;
     }
+
+    const fullOrder: FullOrder = {
+      ...unsignedOrder,
+      ...signature,
+      chainId: params.chainId.toString(),
+      swapContract: swapDeploys[params.chainId],
+    };
+
+    dispatch(setUserOrder(fullOrder));
   }
 );

--- a/src/features/makeOtc/makeOtcActions.ts
+++ b/src/features/makeOtc/makeOtcActions.ts
@@ -4,11 +4,9 @@ import { FullOrder, UnsignedOrder } from "@airswap/typescript";
 import { createOrder } from "@airswap/utils";
 import { createAsyncThunk } from "@reduxjs/toolkit";
 
-import i18n from "i18next";
-
-import { notifyError } from "../../components/Toasts/ToastController";
+import { notifyRejectedByUserError } from "../../components/Toasts/ToastController";
+import { AppErrorType, isAppError } from "../../errors/appError";
 import { createSwapSignature } from "../../helpers/createSwapSignature";
-import { AppErrorType, isAppError } from "../../types/appError";
 import { setError, setStatus, setUserOrder } from "./makeOtcSlice";
 
 export const createOtcOrder = createAsyncThunk(
@@ -44,10 +42,8 @@ export const createOtcOrder = createAsyncThunk(
 
     if (isAppError(signature)) {
       if (signature.type === AppErrorType.rejectedByUser) {
-        notifyError({
-          heading: i18n.t("orders.swapFailed"),
-          cta: i18n.t("orders.swapRejectedByUser"),
-        });
+        dispatch(setStatus("idle"));
+        notifyRejectedByUserError();
       } else {
         dispatch(setStatus("failed"));
         dispatch(setError(signature));

--- a/src/features/makeOtc/makeOtcActions.ts
+++ b/src/features/makeOtc/makeOtcActions.ts
@@ -5,7 +5,7 @@ import { createOrder } from "@airswap/utils";
 import { createAsyncThunk } from "@reduxjs/toolkit";
 
 import { notifyRejectedByUserError } from "../../components/Toasts/ToastController";
-import {AppErrorType, isAppError} from "../../errors/appError";
+import { AppErrorType, isAppError } from "../../errors/appError";
 import { createSwapSignature } from "../../helpers/createSwapSignature";
 import { setError, setStatus, setUserOrder } from "./makeOtcSlice";
 

--- a/src/features/makeOtc/makeOtcSlice.ts
+++ b/src/features/makeOtc/makeOtcSlice.ts
@@ -2,19 +2,18 @@ import { FullOrder } from "@airswap/typescript";
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 
 import { RootState } from "../../app/store";
-import { ErrorType } from "../../constants/errors";
+import { AppError } from "../../types/appError";
 
 export interface MakeOtcState {
   lastUserOrder?: FullOrder;
   status: "idle" | "signing" | "taking" | "failed" | "reset";
   userOrders: FullOrder[];
-  errors: ErrorType[];
+  error?: AppError;
 }
 
 const initialState: MakeOtcState = {
   status: "idle",
   userOrders: [],
-  errors: [],
 };
 
 export const makeOtcSlice = createSlice({
@@ -43,10 +42,10 @@ export const makeOtcSlice = createSlice({
         lastUserOrder: undefined,
       };
     },
-    setErrors: (state, action: PayloadAction<ErrorType[]>): MakeOtcState => {
+    setError: (state, action: PayloadAction<AppError>): MakeOtcState => {
       return {
         ...state,
-        errors: action.payload,
+        error: action.payload,
       };
     },
     reset: (state): MakeOtcState => {
@@ -55,7 +54,7 @@ export const makeOtcSlice = createSlice({
   },
 });
 
-export const { setStatus, setUserOrder, clearLastUserOrder, setErrors, reset } =
+export const { setStatus, setUserOrder, clearLastUserOrder, setError, reset } =
   makeOtcSlice.actions;
 
 export const selectMakeOtcReducer = (state: RootState) => state.makeOtc;

--- a/src/features/makeOtc/makeOtcSlice.ts
+++ b/src/features/makeOtc/makeOtcSlice.ts
@@ -2,7 +2,7 @@ import { FullOrder } from "@airswap/typescript";
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 
 import { RootState } from "../../app/store";
-import { AppError } from "../../types/appError";
+import { AppError } from "../../errors/appError";
 
 export interface MakeOtcState {
   lastUserOrder?: FullOrder;

--- a/src/helpers/createSwapSignature.ts
+++ b/src/helpers/createSwapSignature.ts
@@ -1,7 +1,6 @@
 import { Signature, UnsignedOrder } from "@airswap/typescript";
 import { createSwapSignature as airswapCreateSwapSignature } from "@airswap/utils";
-
-import { ethers } from "ethers";
+import { JsonRpcSigner } from "@ethersproject/providers/src.ts/json-rpc-provider";
 
 import {
   AppError,
@@ -28,7 +27,7 @@ const transformUnknownErrorToAppError = (error: any): AppError => {
 
 export const createSwapSignature = (
   unsignedOrder: UnsignedOrder,
-  signer: ethers.VoidSigner | string,
+  signer: JsonRpcSigner,
   swapContract: string,
   chainId: number
 ): Promise<Signature | AppError> => {

--- a/src/helpers/createSwapSignature.ts
+++ b/src/helpers/createSwapSignature.ts
@@ -9,7 +9,7 @@ import {
   transformToAppError,
 } from "../errors/appError";
 import {
-  ethersProjectError,
+  isEthersProjectError,
   transformEthersProjectErrorToAppError,
 } from "../errors/ethersProjectError";
 import { isRpcError, transformRpcErrorToAppError } from "../errors/rpcError";
@@ -19,7 +19,7 @@ const transformUnknownErrorToAppError = (error: any): AppError => {
     return transformRpcErrorToAppError(error);
   }
 
-  if (ethersProjectError(error)) {
+  if (isEthersProjectError(error)) {
     return transformEthersProjectErrorToAppError(error);
   }
 

--- a/src/helpers/createSwapSignature.ts
+++ b/src/helpers/createSwapSignature.ts
@@ -1,0 +1,58 @@
+import { Signature, UnsignedOrder } from "@airswap/typescript";
+import { createSwapSignature as airswapCreateSwapSignature } from "@airswap/utils";
+
+import { ethers } from "ethers";
+
+import { AppError, AppErrorType, transformToAppError } from "../types/appError";
+
+export interface CreateSwapSignatureError {
+  argument: string;
+  value: string;
+  code: "INVALID_ARGUMENT";
+}
+
+const transformUnknownErrorToAppError = (error: any): AppError => {
+  if (error.code === 4001) {
+    return transformToAppError(AppErrorType.rejectedByUser, error);
+  }
+
+  if (error.argument === "address") {
+    return transformToAppError(
+      AppErrorType.invalidAddress,
+      error,
+      error.argument
+    );
+  }
+
+  if (error.argument === "value") {
+    return transformToAppError(
+      AppErrorType.invalidValue,
+      error,
+      error.argument
+    );
+  }
+
+  return transformToAppError(AppErrorType.unknownError, error);
+};
+
+export const createSwapSignature = (
+  unsignedOrder: UnsignedOrder,
+  signer: ethers.VoidSigner | string,
+  swapContract: string,
+  chainId: number
+): Promise<Signature | AppError> => {
+  return new Promise<Signature | AppError>(async (resolve) => {
+    try {
+      const signature = await airswapCreateSwapSignature(
+        unsignedOrder,
+        // @ts-ignore
+        signer,
+        swapContract,
+        chainId
+      );
+      resolve(signature);
+    } catch (e: unknown) {
+      resolve(transformUnknownErrorToAppError(e));
+    }
+  });
+};

--- a/src/helpers/createSwapSignature.ts
+++ b/src/helpers/createSwapSignature.ts
@@ -5,31 +5,29 @@ import { ethers } from "ethers";
 
 import { AppError, AppErrorType, transformToAppError } from "../types/appError";
 
-export interface CreateSwapSignatureError {
-  argument: string;
-  value: string;
-  code: "INVALID_ARGUMENT";
-}
-
 const transformUnknownErrorToAppError = (error: any): AppError => {
+  // Error code could be an eth rpc or provider error found here:
+  // node_modules/eth-rpc-errors/dist/error-constants.d.ts
+
   if (error.code === 4001) {
     return transformToAppError(AppErrorType.rejectedByUser, error);
   }
 
+  if (error.code === 4100) {
+    return transformToAppError(AppErrorType.unauthorized, error);
+  }
+
+  // Or there's a different error from eth-sig-util I think. Which looks like this:
+  // argument: string;
+  // value: string;
+  // code: "INVALID_ARGUMENT";
+
   if (error.argument === "address") {
-    return transformToAppError(
-      AppErrorType.invalidAddress,
-      error,
-      error.argument
-    );
+    return transformToAppError(AppErrorType.invalidAddress, error, error.value);
   }
 
   if (error.argument === "value") {
-    return transformToAppError(
-      AppErrorType.invalidValue,
-      error,
-      error.argument
-    );
+    return transformToAppError(AppErrorType.invalidValue, error, error.value);
   }
 
   return transformToAppError(AppErrorType.unknownError, error);

--- a/src/helpers/createSwapSignature.ts
+++ b/src/helpers/createSwapSignature.ts
@@ -42,8 +42,9 @@ export const createSwapSignature = (
         chainId
       );
       resolve(signature);
-    } catch (e: unknown) {
-      resolve(transformUnknownErrorToAppError(e));
+    } catch (error: unknown) {
+      console.error(error);
+      resolve(transformUnknownErrorToAppError(error));
     }
   });
 };

--- a/src/helpers/createSwapSignature.ts
+++ b/src/helpers/createSwapSignature.ts
@@ -9,9 +9,9 @@ import {
   transformToAppError,
 } from "../errors/appError";
 import {
-  isEthSigUtilError,
-  transformEthSigUtilErrorToAppError,
-} from "../errors/ethSigUtilError";
+  ethersProjectError,
+  transformEthersProjectErrorToAppError,
+} from "../errors/ethersProjectError";
 import { isRpcError, transformRpcErrorToAppError } from "../errors/rpcError";
 
 const transformUnknownErrorToAppError = (error: any): AppError => {
@@ -19,8 +19,8 @@ const transformUnknownErrorToAppError = (error: any): AppError => {
     return transformRpcErrorToAppError(error);
   }
 
-  if (isEthSigUtilError(error)) {
-    return transformEthSigUtilErrorToAppError(error);
+  if (ethersProjectError(error)) {
+    return transformEthersProjectErrorToAppError(error);
   }
 
   return transformToAppError(AppErrorType.unknownError, error);

--- a/src/helpers/createSwapSignature.ts
+++ b/src/helpers/createSwapSignature.ts
@@ -3,31 +3,24 @@ import { createSwapSignature as airswapCreateSwapSignature } from "@airswap/util
 
 import { ethers } from "ethers";
 
-import { AppError, AppErrorType, transformToAppError } from "../types/appError";
+import {
+  AppError,
+  AppErrorType,
+  transformToAppError,
+} from "../errors/appError";
+import {
+  isEthSigUtilError,
+  transformEthSigUtilErrorToAppError,
+} from "../errors/ethSigUtilError";
+import { isRpcError, transformRpcErrorToAppError } from "../errors/rpcError";
 
 const transformUnknownErrorToAppError = (error: any): AppError => {
-  // Error code could be an eth rpc or provider error found here:
-  // node_modules/eth-rpc-errors/dist/error-constants.d.ts
-
-  if (error.code === 4001) {
-    return transformToAppError(AppErrorType.rejectedByUser, error);
+  if (isRpcError(error)) {
+    return transformRpcErrorToAppError(error);
   }
 
-  if (error.code === 4100) {
-    return transformToAppError(AppErrorType.unauthorized, error);
-  }
-
-  // Or there's a different error from eth-sig-util I think. Which looks like this:
-  // argument: string;
-  // value: string;
-  // code: "INVALID_ARGUMENT";
-
-  if (error.argument === "address") {
-    return transformToAppError(AppErrorType.invalidAddress, error, error.value);
-  }
-
-  if (error.argument === "value") {
-    return transformToAppError(AppErrorType.invalidValue, error, error.value);
+  if (isEthSigUtilError(error)) {
+    return transformEthSigUtilErrorToAppError(error);
   }
 
   return transformToAppError(AppErrorType.unknownError, error);

--- a/src/helpers/transformErrorCodeToError.ts
+++ b/src/helpers/transformErrorCodeToError.ts
@@ -1,3 +1,5 @@
+// This helper is used in the swap widget. I'd like to eventually replace this
+// with transformUnknownErrorToAppError.
 import { errorCodes } from "eth-rpc-errors/dist/error-constants";
 
 import {

--- a/src/helpers/transformErrorCodeToError.ts
+++ b/src/helpers/transformErrorCodeToError.ts
@@ -1,6 +1,5 @@
 // This helper is used in the swap widget. I'd like to eventually replace this
 // with the error handling in src/errors.
-
 import { errorCodes } from "eth-rpc-errors/dist/error-constants";
 
 import {

--- a/src/helpers/transformErrorCodeToError.ts
+++ b/src/helpers/transformErrorCodeToError.ts
@@ -1,5 +1,6 @@
 // This helper is used in the swap widget. I'd like to eventually replace this
-// with transformUnknownErrorToAppError.
+// with the error handling in src/errors.
+
 import { errorCodes } from "eth-rpc-errors/dist/error-constants";
 
 import {

--- a/src/hooks/useEnsAddress.ts
+++ b/src/hooks/useEnsAddress.ts
@@ -1,0 +1,27 @@
+import { useEffect, useState } from "react";
+
+import { Web3Provider } from "@ethersproject/providers";
+import { useWeb3React } from "@web3-react/core";
+
+const useEnsAddress = (address?: string): string | undefined => {
+  const { library } = useWeb3React<Web3Provider>();
+  const [lookedUpAddress, setLookedUpAddress] = useState<string | null>(null);
+
+  const lookupAddress = async (library: Web3Provider, value: string) => {
+    // Note: lookupAddress only seems to work on mainnet.
+    const newLookedUpAddress = await library.lookupAddress(value);
+    setLookedUpAddress(newLookedUpAddress);
+  };
+
+  useEffect(() => {
+    if (!library || !address) {
+      return;
+    }
+
+    lookupAddress(library, address);
+  }, [library, address]);
+
+  return lookedUpAddress || undefined;
+};
+
+export default useEnsAddress;

--- a/src/pages/OrderDetail/OrderDetail.tsx
+++ b/src/pages/OrderDetail/OrderDetail.tsx
@@ -17,7 +17,7 @@ const OrderDetail: FC = () => {
   useEffect(() => {
     if (compressedOrder) {
       // Coltrane gets type/overload error without the <any>, not sure why.
-      dispatch<any>(decompressAndSetActiveOrder(compressedOrder));
+      dispatch(decompressAndSetActiveOrder(compressedOrder));
     }
   }, [dispatch, compressedOrder]);
 

--- a/src/types/appError.ts
+++ b/src/types/appError.ts
@@ -1,0 +1,34 @@
+export enum AppErrorType {
+  invalidAddress = "invalid-address",
+  invalidValue = "invalid-value",
+  rejectedByUser = "rejected-by-user",
+  unauthorized = "unauthorized",
+  unknownError = "unknown-error",
+}
+
+export type AppError = {
+  argument?: string;
+  error: unknown;
+  type: AppErrorType;
+};
+
+export const isAppError = (x: any): x is AppError => {
+  return (
+    typeof x === "object" &&
+    x !== null &&
+    "type" in x &&
+    Object.values(AppErrorType).includes(x.type)
+  );
+};
+
+export function transformToAppError(
+  type: AppErrorType,
+  error: unknown,
+  argument?: string
+): AppError {
+  return {
+    argument,
+    error,
+    type,
+  };
+}


### PR DESCRIPTION
Fixes #605 and #608 

While working on the `createOtcOrder` the error handling was really bugging me because we get different formats of errors from airswap-protocols.

So I decided to add some new error handling and a new `isAppError` guard which we will first try out in the new otc feature.

I also added a new ErrorList component, the legacy one I moved to the SwapWidget subcomponents.
