### PR TITLE
WalletConnect fix

### DIFF
--- a/.env
+++ b/.env
@@ -2,7 +2,7 @@
 # Mainnet
 REACT_APP_RPC_URL_1=""
 # Rinkeby
-REACT_APP_RPC_URL_4=""
+REACT_APP_RPC_URL_5=""
 
 # For Gas Station API (Gas prices)
 REACT_APP_DEFIPULSE_API_KEY=

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,6 +11,9 @@ jobs:
         uses: actions/checkout@v2.3.1
 
       - name: Install and Build 🔧
+        env:
+          REACT_APP_RPC_URL_1: ${{ secrets.REACT_APP_RPC_URL_1 }}
+          REACT_APP_RPC_URL_5: ${{ secrets.REACT_APP_RPC_URL_5 }}
         run: |
           yarn
           yarn build

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@types/styled-components": "^5.1.12",
     "@web3-react/core": "^6.1.9",
     "@web3-react/injected-connector": "^6.0.7",
-    "@web3-react/walletconnect-connector": "6.2.4",
+    "@web3-react/walletconnect-connector": "^7.0.2-alpha.0",
     "bignumber.js": "^9.0.1",
     "classnames": "^2.3.1",
     "date-fns": "^2.28.0",

--- a/src/constants/supportedWalletProviders.ts
+++ b/src/constants/supportedWalletProviders.ts
@@ -42,7 +42,7 @@ const SUPPORTED_WALLET_PROVIDERS: WalletProvider[] = [
         cachedConnectors.WalletConnect = new WalletConnectConnector({
           rpc: {
             1: process.env.REACT_APP_RPC_URL_1 || "",
-            4: process.env.REACT_APP_RPC_URL_4 || "",
+            5: process.env.REACT_APP_RPC_URL_5 || "",
           },
         });
       }


### PR DESCRIPTION
- tested WalletConnect using rainbow and goerli
- connected wallet, sent read-only transactions
- approved and signed make order in OTC swap
- WalletConnect supports Mainnet and Goerli with this change