### PR TITLE
652: Added tooltip to order status indicator

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -65,7 +65,8 @@
     "fee": "Fee",
     "expiry": "Expiry",
     "pair": "Pair",
-    "close": "close"
+    "close": "close",
+    "active": "Active"
   },
   "information": {
     "join.title": "Join AirSwap",

--- a/src/components/MyOrdersWidget/helpers/index.ts
+++ b/src/components/MyOrdersWidget/helpers/index.ts
@@ -2,9 +2,11 @@ import { FullOrder } from "@airswap/typescript";
 import { TokenInfo } from "@uniswap/token-lists";
 
 import { BigNumber } from "bignumber.js";
+import i18n from "i18next";
 
 import { OrdersSortType } from "../../../features/myOrders/myOrdersSlice";
 import findEthOrTokenByAddress from "../../../helpers/findEthOrTokenByAddress";
+import { OrderStatus } from "../../../types/orderStatus";
 
 export const getTokenAmountWithDecimals = (
   amount: string,
@@ -60,4 +62,20 @@ export const getSortedOrders = (
   }
 
   return array;
+};
+
+export const getOrderStatusTranslation = (status: OrderStatus): string => {
+  if (status === OrderStatus.canceled) {
+    return i18n.t("common.canceled");
+  }
+
+  if (status === OrderStatus.taken) {
+    return i18n.t("common.taken");
+  }
+
+  if (status === OrderStatus.expired) {
+    return i18n.t("common.expired");
+  }
+
+  return i18n.t("common.active");
 };

--- a/src/components/MyOrdersWidget/subcomponents/MyOrdersList/MyOrdersList.styles.tsx
+++ b/src/components/MyOrdersWidget/subcomponents/MyOrdersList/MyOrdersList.styles.tsx
@@ -50,19 +50,28 @@ export const TooltipContainer = styled.div`
 `;
 
 export const StyledTooltip = styled(Tooltip)<{
-  activeDeleteButton: number;
+  orderIndex: number;
   containerScrollTop: number;
 }>`
-  // display: none;
   justify-content: flex-start;
   position: absolute;
   top: calc(
     4rem + ${({ containerScrollTop }) => -containerScrollTop}px + 3rem *
-      ${({ activeDeleteButton }) => activeDeleteButton}
+      ${({ orderIndex }) => orderIndex}
   );
-  left: 100%;
-  margin-left: -1rem;
   width: auto;
   z-index: 3;
   pointer-events: none;
+`;
+
+export const DeleteButtonTooltip = styled(StyledTooltip)`
+  left: 100%;
+  margin-left: -1rem;
+`;
+
+export const OrderIndicatorTooltip = styled(StyledTooltip)`
+  justify-content: flex-end;
+  margin-left: 0.5rem;
+  left: 0;
+  width: 0;
 `;

--- a/src/components/MyOrdersWidget/subcomponents/MyOrdersList/MyOrdersList.tsx
+++ b/src/components/MyOrdersWidget/subcomponents/MyOrdersList/MyOrdersList.tsx
@@ -5,13 +5,16 @@ import { FullOrder } from "@airswap/typescript";
 
 import { OrdersSortType } from "../../../../features/myOrders/myOrdersSlice";
 import useWindowSize from "../../../../hooks/useWindowSize";
+import { OrderStatus } from "../../../../types/orderStatus";
+import { getOrderStatusTranslation } from "../../helpers";
 import Order from "../Order/Order";
 import {
   Container,
+  DeleteButtonTooltip,
+  OrderIndicatorTooltip,
   OrdersContainer,
   Shadow,
   StyledMyOrdersListSortButtons,
-  StyledTooltip,
 } from "./MyOrdersList.styles";
 
 interface MyOrdersListProps {
@@ -35,24 +38,41 @@ const MyOrdersList: FC<MyOrdersListProps> = ({
   const containerRef = useRef<HTMLDivElement>(null);
   const { width: windowWidth } = useWindowSize();
 
-  const [activeDeleteButton, setActiveDeleteButton] = useState<number>();
+  const [activeDeleteButtonTooltipIndex, setActiveDeleteButtonTooltipIndex] =
+    useState<number>();
+  const [
+    activeOrderIndicatorTooltipIndex,
+    setActiveOrderIndicatorTooltipIndex,
+  ] = useState<number>();
   const [tooltipText, setTooltipText] = useState("");
   const [containerScrollTop, setContainerScrollTop] = useState(0);
   const [containerWidth, setContainerWidth] = useState(0);
 
   const handleDeleteOrderButtonMouseEnter = (
     index: number,
-    isExpired: boolean
+    orderIsOpen: boolean
   ) => {
-    setActiveDeleteButton(index);
-    const tooltipText = isExpired
-      ? t("orders.removeFromList")
-      : t("orders.cancelSwap");
+    setActiveDeleteButtonTooltipIndex(index);
+    const tooltipText = orderIsOpen
+      ? t("orders.cancelSwap")
+      : t("orders.removeFromList");
     setTooltipText(tooltipText);
   };
 
   const handleDeleteOrderButtonMouseLeave = () => {
-    setActiveDeleteButton(undefined);
+    setActiveDeleteButtonTooltipIndex(undefined);
+  };
+
+  const handleStatusIndicatorMouseEnter = (
+    index: number,
+    status: OrderStatus
+  ) => {
+    setTooltipText(getOrderStatusTranslation(status));
+    setActiveOrderIndicatorTooltipIndex(index);
+  };
+
+  const handleStatusIndicatorMouseLeave = () => {
+    setActiveOrderIndicatorTooltipIndex(undefined);
   };
 
   const handleOnContainerScroll = () => {
@@ -92,15 +112,25 @@ const MyOrdersList: FC<MyOrdersListProps> = ({
             onDeleteOrderButtonClick={onDeleteOrderButtonClick}
             onDeleteOrderButtonMouseEnter={handleDeleteOrderButtonMouseEnter}
             onDeleteOrderButtonMouseLeave={handleDeleteOrderButtonMouseLeave}
+            onStatusIndicatorMouseEnter={handleStatusIndicatorMouseEnter}
+            onStatusIndicatorMouseLeave={handleStatusIndicatorMouseLeave}
           />
         ))}
-        {activeDeleteButton !== undefined && (
-          <StyledTooltip
-            activeDeleteButton={activeDeleteButton || 0}
+        {activeDeleteButtonTooltipIndex !== undefined && (
+          <DeleteButtonTooltip
+            orderIndex={activeDeleteButtonTooltipIndex || 0}
             containerScrollTop={containerScrollTop}
           >
             {tooltipText}
-          </StyledTooltip>
+          </DeleteButtonTooltip>
+        )}
+        {activeOrderIndicatorTooltipIndex !== undefined && (
+          <OrderIndicatorTooltip
+            orderIndex={activeOrderIndicatorTooltipIndex || 0}
+            containerScrollTop={containerScrollTop}
+          >
+            {tooltipText}
+          </OrderIndicatorTooltip>
         )}
       </OrdersContainer>
       <Shadow />

--- a/src/components/MyOrdersWidget/subcomponents/Order/Order.styles.tsx
+++ b/src/components/MyOrdersWidget/subcomponents/Order/Order.styles.tsx
@@ -1,9 +1,10 @@
 import { NavLink } from "react-router-dom";
 
-import styled from "styled-components/macro";
+import styled, { DefaultTheme } from "styled-components/macro";
 
 import { InputOrButtonBorderStyleType2 } from "../../../../style/mixins";
 import { fontMono } from "../../../../style/themes";
+import { OrderStatus } from "../../../../types/orderStatus";
 import IconButton from "../../../IconButton/IconButton";
 import TokenLogo from "../../../TokenLogo/TokenLogo";
 import { MyOrdersGrid } from "../../MyOrdersWidget.styles";
@@ -15,7 +16,22 @@ export const Circle = styled.div`
   background: ${({ theme }) => theme.colors.green};
 `;
 
-export const Container = styled.div<{ isUsedOrExpired: boolean }>`
+const getIndicatorColor = (
+  theme: DefaultTheme,
+  orderStatus: OrderStatus
+): string => {
+  if (orderStatus === OrderStatus.canceled) {
+    return theme.colors.red;
+  }
+
+  if (orderStatus === OrderStatus.open) {
+    return theme.colors.green;
+  }
+
+  return theme.colors.borderGrey;
+};
+
+export const Container = styled.div<{ orderStatus: OrderStatus }>`
   ${MyOrdersGrid};
 
   position: relative;
@@ -24,17 +40,19 @@ export const Container = styled.div<{ isUsedOrExpired: boolean }>`
   height: 3rem;
 
   ${Circle} {
-    background: ${({ theme, isUsedOrExpired }) =>
-      isUsedOrExpired ? theme.colors.borderGrey : theme.colors.green};
+    background: ${({ theme, orderStatus }) =>
+      getIndicatorColor(theme, orderStatus)};
   }
 `;
 
-export const ActiveIndicator = styled.div`
+export const StatusIndicator = styled.div`
   display: flex;
   justify-content: center;
+  align-items: center;
   position: relative;
+  height: 1rem;
+  cursor: pointer;
   z-index: 2;
-  pointer-events: none;
 `;
 
 export const StyledTokenLogo = styled(TokenLogo)`

--- a/src/components/MyOrdersWidget/subcomponents/Order/Order.tsx
+++ b/src/components/MyOrdersWidget/subcomponents/Order/Order.tsx
@@ -15,9 +15,9 @@ import { getTokenAmountWithDecimals } from "../../helpers";
 import {
   ActionButton,
   ActionButtonContainer,
-  ActiveIndicator,
   Circle,
   Container,
+  StatusIndicator,
   StyledNavLink,
   StyledTokenLogo,
   Text,
@@ -28,8 +28,10 @@ interface OrderProps {
   order: FullOrder;
   index: number;
   onDeleteOrderButtonClick: (order: FullOrder) => void;
-  onDeleteOrderButtonMouseEnter: (index: number, isExpired: boolean) => void;
+  onDeleteOrderButtonMouseEnter: (index: number, orderIsOpen: boolean) => void;
   onDeleteOrderButtonMouseLeave: () => void;
+  onStatusIndicatorMouseEnter: (index: number, status: OrderStatus) => void;
+  onStatusIndicatorMouseLeave: () => void;
   className?: string;
 }
 
@@ -39,6 +41,8 @@ const Order: FC<PropsWithChildren<OrderProps>> = ({
   onDeleteOrderButtonClick,
   onDeleteOrderButtonMouseEnter,
   onDeleteOrderButtonMouseLeave,
+  onStatusIndicatorMouseEnter,
+  onStatusIndicatorMouseLeave,
   className,
 }) => {
   const senderTokenInfo = useTokenInfo(order.senderToken);
@@ -58,7 +62,6 @@ const Order: FC<PropsWithChildren<OrderProps>> = ({
   );
   const expiry = useMemo(() => parseInt(order.expiry) * 1000, [order]);
   const orderString = useMemo(() => compressFullOrder(order), [order]);
-  const isExpired = new Date().getTime() > expiry;
   const orderStatus = useOrderStatus(order);
 
   const handleDeleteOrderButtonClick = () => {
@@ -66,13 +69,13 @@ const Order: FC<PropsWithChildren<OrderProps>> = ({
   };
 
   return (
-    <Container
-      isUsedOrExpired={isExpired || orderStatus !== OrderStatus.open}
-      className={className}
-    >
-      <ActiveIndicator>
+    <Container orderStatus={orderStatus} className={className}>
+      <StatusIndicator
+        onMouseEnter={() => onStatusIndicatorMouseEnter(index, orderStatus)}
+        onMouseLeave={onStatusIndicatorMouseLeave}
+      >
         <Circle />
-      </ActiveIndicator>
+      </StatusIndicator>
       <TokenLogos>
         <StyledTokenLogo size="tiny" tokenInfo={signerTokenInfo} />
         <StyledTokenLogo size="tiny" tokenInfo={senderTokenInfo} />
@@ -87,12 +90,15 @@ const Order: FC<PropsWithChildren<OrderProps>> = ({
           <LoadingSpinner />
         ) : (
           <ActionButton
-            icon={
-              isExpired || orderStatus !== OrderStatus.open ? "bin" : "button-x"
-            }
-            iconSize={isExpired ? 0.75 : 0.675}
+            icon={orderStatus !== OrderStatus.open ? "bin" : "button-x"}
+            iconSize={orderStatus === OrderStatus.open ? 0.75 : 0.675}
             onClick={handleDeleteOrderButtonClick}
-            onMouseEnter={() => onDeleteOrderButtonMouseEnter(index, isExpired)}
+            onMouseEnter={() =>
+              onDeleteOrderButtonMouseEnter(
+                index,
+                orderStatus === OrderStatus.open
+              )
+            }
             onMouseLeave={onDeleteOrderButtonMouseLeave}
           />
         )}

--- a/src/components/OrderDetailWidget/OrderDetailWidget.tsx
+++ b/src/components/OrderDetailWidget/OrderDetailWidget.tsx
@@ -8,7 +8,6 @@ import { useToggle } from "@react-hookz/web";
 import { UnsupportedChainIdError, useWeb3React } from "@web3-react/core";
 
 import { BigNumber } from "bignumber.js";
-import compareAsc from "date-fns/compareAsc";
 
 import { useAppDispatch, useAppSelector } from "../../app/hooks";
 import { nativeCurrencyAddress } from "../../constants/nativeCurrency";
@@ -109,9 +108,6 @@ const OrderDetailWidget: FC<OrderDetailWidgetProps> = ({ order }) => {
   const parsedExpiry = useMemo(() => {
     return new Date(parseInt(order.expiry) * 1000);
   }, [order]);
-  const orderIsExpired = useMemo(() => {
-    return compareAsc(new Date(), parsedExpiry) === 1;
-  }, [parsedExpiry]);
 
   const [showFeeInfo, toggleShowFeeInfo] = useToggle(false);
 
@@ -217,7 +213,7 @@ const OrderDetailWidget: FC<OrderDetailWidgetProps> = ({ order }) => {
         onMaxButtonClick={() => {}}
       />
       <StyledInfoButtons
-        isExpired={orderIsExpired}
+        isExpired={orderStatus === OrderStatus.expired}
         isDifferentChainId={walletChainIdIsDifferentThanOrderChainId}
         isIntendedRecipient={userIsIntendedRecipient}
         isMakerOfSwap={userIsMakerOfSwap}
@@ -232,7 +228,7 @@ const OrderDetailWidget: FC<OrderDetailWidgetProps> = ({ order }) => {
       <ActionButtons
         hasInsufficientBalance={hasInsufficientTokenBalance}
         hasInsufficientAllowance={hasInsufficientAllowance}
-        isExpired={orderIsExpired}
+        isExpired={orderStatus === OrderStatus.expired}
         isCanceled={orderStatus === OrderStatus.canceled}
         isTaken={orderStatus === OrderStatus.taken}
         isDifferentChainId={walletChainIdIsDifferentThanOrderChainId}

--- a/src/components/OrderDetailWidget/hooks/useOrderStatus.tsx
+++ b/src/components/OrderDetailWidget/hooks/useOrderStatus.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 
 import { FullOrder } from "@airswap/typescript";
 import { useWeb3React } from "@web3-react/core";
@@ -11,7 +11,9 @@ export const useOrderStatus = (order: FullOrder): OrderStatus => {
   const { library } = useWeb3React();
 
   const [isTaken, setIsTaken] = useState(false);
+  const expiry = useMemo(() => parseInt(order.expiry) * 1000, [order]);
   const isCanceled = useCancellationSuccess(order.nonce);
+  const isExpired = new Date().getTime() > expiry;
 
   const asyncGetTakenState = useCallback(
     async (order: FullOrder) => {
@@ -34,5 +36,9 @@ export const useOrderStatus = (order: FullOrder): OrderStatus => {
     return OrderStatus.canceled;
   }
 
-  return isTaken ? OrderStatus.taken : OrderStatus.open;
+  if (isTaken) {
+    return OrderStatus.taken;
+  }
+
+  return isExpired ? OrderStatus.expired : OrderStatus.open;
 };

--- a/src/components/OrderDetailWidget/subcomponents/OrderStatusInfo/OrderStatusInfo.tsx
+++ b/src/components/OrderDetailWidget/subcomponents/OrderStatusInfo/OrderStatusInfo.tsx
@@ -20,7 +20,7 @@ const OrderStatusInfo: FC<OrderStatusInfoProps> = ({
 }) => {
   const { t } = useTranslation();
 
-  if (status === OrderStatus.open) {
+  if (status === OrderStatus.open || status === OrderStatus.expired) {
     return <ExpiryIndicator expiry={expiry} className={className} />;
   }
 

--- a/src/features/takeOtc/takeOtcActions.ts
+++ b/src/features/takeOtc/takeOtcActions.ts
@@ -109,7 +109,6 @@ export const cancelOrder = createAsyncThunk(
     // post-cancel clean up
     const isCancelled = await getNonceUsed(params.order, params.library);
     dispatch(mineTransaction(tx));
-    dispatch(removeUserOrder(params.order));
 
     if (isCancelled) {
       dispatch(setIsCancelSuccessFull(true));

--- a/src/types/orderStatus.ts
+++ b/src/types/orderStatus.ts
@@ -2,4 +2,5 @@ export enum OrderStatus {
   canceled = "canceled",
   open = "open",
   taken = "taken",
+  expired = "expired",
 }


### PR DESCRIPTION
Fixes #652

Also gave canceled orders a red indicator that has "Canceled" tooltip.

![Screenshot 2022-11-06 at 21 36 23](https://user-images.githubusercontent.com/86911296/200193855-d72590df-cc30-4d2d-be63-21abc463f31c.png)
