### PR TITLE
Fixes #668 fee modal and info buttons

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -182,7 +182,8 @@
     "transaction": "{{senderAmount}} {{senderToken}} → {{signerAmount}} {{signerToken}}",
     "cancelComplete": "Cancel Complete",
     "cancelFail": "Cancel Failed",
-    "copied": "Copied to Clipboard"
+    "copiedToClipboard": "Copied to Clipboard",
+    "copyFailed": "Copy Failed"
   },
   "validatorErrors": {
     "signature_invalid": "Invalid signature",

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -181,7 +181,8 @@
     "approve": "Approve {{symbol}}",
     "transaction": "{{senderAmount}} {{senderToken}} → {{signerAmount}} {{signerToken}}",
     "cancelComplete": "Cancel Complete",
-    "cancelFail": "Cancel Failed"
+    "cancelFail": "Cancel Failed",
+    "copied": "Copied to Clipboard"
   },
   "validatorErrors": {
     "signature_invalid": "Invalid signature",

--- a/src/components/InformationModals/subcomponents/FeeModal/FeeModal.styles.tsx
+++ b/src/components/InformationModals/subcomponents/FeeModal/FeeModal.styles.tsx
@@ -1,7 +1,11 @@
 import styled from "styled-components/macro";
 
-import { OverlayActionButton } from "../../../Overlay/Overlay.styles";
+import { sizes } from "../../../../style/sizes";
 
-export const StyledCloseButton = styled(OverlayActionButton)`
-  margin-top: 1.5rem;
+export const FeeContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  height: 100%;
+  padding-bottom: ${sizes.tradeContainerPadding};
 `;

--- a/src/components/InformationModals/subcomponents/FeeModal/FeeModal.tsx
+++ b/src/components/InformationModals/subcomponents/FeeModal/FeeModal.tsx
@@ -1,11 +1,9 @@
 import React, { FC } from "react";
 import { useTranslation } from "react-i18next";
 
-import {
-  ModalParagraph,
-  ScrollableModalContainer,
-} from "../../../../styled-components/Modal/Modal";
-import { StyledCloseButton } from "./FeeModal.styles";
+import { ModalParagraph } from "../../../../styled-components/Modal/Modal";
+import { OverlayActionButton } from "../../../Overlay/Overlay.styles";
+import { FeeContainer } from "./FeeModal.styles";
 
 type FeeModalProps = {
   onCloseButtonClick: () => void;
@@ -15,12 +13,12 @@ const FeeModal: FC<FeeModalProps> = ({ onCloseButtonClick }) => {
   const { t } = useTranslation();
 
   return (
-    <ScrollableModalContainer>
-      <ModalParagraph>Fee text here</ModalParagraph>
-      <StyledCloseButton onClick={onCloseButtonClick}>
+    <FeeContainer>
+      <ModalParagraph>Fee Text Here</ModalParagraph>
+      <OverlayActionButton onClick={onCloseButtonClick}>
         {t("common.back")}
-      </StyledCloseButton>
-    </ScrollableModalContainer>
+      </OverlayActionButton>
+    </FeeContainer>
   );
 };
 

--- a/src/components/OrderDetailWidget/OrderDetailWidget.tsx
+++ b/src/components/OrderDetailWidget/OrderDetailWidget.tsx
@@ -39,6 +39,7 @@ import { ErrorList } from "../ErrorList/ErrorList";
 import FeeModal from "../InformationModals/subcomponents/FeeModal/FeeModal";
 import Overlay from "../Overlay/Overlay";
 import SwapInputs from "../SwapInputs/SwapInputs";
+import { notifyCopySuccess } from "../Toasts/ToastController";
 import { Container, StyledInfoButtons } from "./OrderDetailWidget.styles";
 import useFormattedTokenAmount from "./hooks/useFormattedTokenAmount";
 import { useOrderStatus } from "./hooks/useOrderStatus";
@@ -120,6 +121,7 @@ const OrderDetailWidget: FC<OrderDetailWidgetProps> = ({ order }) => {
 
   const handleCopyButtonClick = () => {
     navigator.clipboard.writeText(window.location.toString());
+    notifyCopySuccess();
   };
 
   const takeOrder = async () => {

--- a/src/components/OrderDetailWidget/OrderDetailWidget.tsx
+++ b/src/components/OrderDetailWidget/OrderDetailWidget.tsx
@@ -27,6 +27,7 @@ import {
   setErrors,
 } from "../../features/takeOtc/takeOtcSlice";
 import switchToEthereumChain from "../../helpers/switchToEthereumChain";
+import writeTextToClipboard from "../../helpers/writeTextToClipboard";
 import useApprovalPending from "../../hooks/useApprovalPending";
 import useInsufficientBalance from "../../hooks/useInsufficientBalance";
 import useOrderTransactionLink from "../../hooks/useOrderTransactionLink";
@@ -39,7 +40,7 @@ import { ErrorList } from "../ErrorList/ErrorList";
 import FeeModal from "../InformationModals/subcomponents/FeeModal/FeeModal";
 import Overlay from "../Overlay/Overlay";
 import SwapInputs from "../SwapInputs/SwapInputs";
-import { notifyCopySuccess } from "../Toasts/ToastController";
+import { notifyCopySuccess, notifyError } from "../Toasts/ToastController";
 import { Container, StyledInfoButtons } from "./OrderDetailWidget.styles";
 import useFormattedTokenAmount from "./hooks/useFormattedTokenAmount";
 import { useOrderStatus } from "./hooks/useOrderStatus";
@@ -119,9 +120,11 @@ const OrderDetailWidget: FC<OrderDetailWidgetProps> = ({ order }) => {
     });
   };
 
-  const handleCopyButtonClick = () => {
-    navigator.clipboard.writeText(window.location.toString());
-    notifyCopySuccess();
+  const handleCopyButtonClick = async () => {
+    const copy = await writeTextToClipboard(window.location.toString());
+    copy
+      ? notifyCopySuccess()
+      : notifyError({ heading: t("toast.copyFailed"), cta: "" });
   };
 
   const takeOrder = async () => {

--- a/src/components/OrderDetailWidget/subcomponents/OrderRecipientInfo/OrderRecipientInfo.tsx
+++ b/src/components/OrderDetailWidget/subcomponents/OrderRecipientInfo/OrderRecipientInfo.tsx
@@ -1,7 +1,7 @@
 import React, { FC, useState } from "react";
 import { useTranslation } from "react-i18next";
 
-import writeAddressToClipboard from "../../../../helpers/writeAddressToClipboard";
+import writeTextToClipboard from "../../../../helpers/writeTextToClipboard";
 import useEnsAddress from "../../../../hooks/useEnsAddress";
 import { OrderType } from "../../../../types/orderTypes";
 import {
@@ -37,7 +37,7 @@ const OrderRecipientInfo: FC<OrderRecipientInfoProps> = ({
   const handleClick = async () => {
     if (readableAddress) {
       setWriteAddressToClipboardSuccess(
-        await writeAddressToClipboard(readableAddress)
+        await writeTextToClipboard(readableAddress)
       );
     }
   };

--- a/src/components/Toasts/CopyToast.tsx
+++ b/src/components/Toasts/CopyToast.tsx
@@ -1,0 +1,44 @@
+import { FC } from "react";
+import { HiX } from "react-icons/hi";
+
+import Icon from "../Icon/Icon";
+import { InfoHeading } from "../Typography/Typography";
+import {
+  Container,
+  IconContainer,
+  HiXContainer,
+  TextContainer,
+} from "./Toast.styles";
+
+export type CopyToastProps = {
+  /**
+   * Function to trigger closing of toast
+   */
+  onClose: () => void;
+  heading: string;
+};
+
+const CopyToast: FC<CopyToastProps> = ({ onClose, heading }) => {
+  return (
+    <Container>
+      <IconContainer error={false}>
+        <Icon name="copy2" />
+      </IconContainer>
+      <TextContainer>
+        <InfoHeading>{heading}</InfoHeading>
+      </TextContainer>
+      <HiXContainer>
+        <HiX
+          style={{
+            width: "1rem",
+            height: "1rem",
+            cursor: "pointer",
+          }}
+          onClick={onClose}
+        />
+      </HiXContainer>
+    </Container>
+  );
+};
+
+export default CopyToast;

--- a/src/components/Toasts/ToastController.tsx
+++ b/src/components/Toasts/ToastController.tsx
@@ -13,6 +13,7 @@ import {
 } from "../../features/transactions/transactionsSlice";
 import findEthOrTokenByAddress from "../../helpers/findEthOrTokenByAddress";
 import ConfirmationToast from "./ConfirmationToast";
+import CopyToast from "./CopyToast";
 import ErrorToast from "./ErrorToast";
 import OrderToast from "./OrderToast";
 import TransactionToast from "./TransactionToast";
@@ -120,6 +121,20 @@ export const notifyOrderCreated = (order: FullOrder) => {
     (t) => <OrderToast onClose={() => toast.dismiss(t.id)} order={order} />,
     {
       duration: 3000,
+    }
+  );
+};
+
+export const notifyCopySuccess = () => {
+  toast(
+    (t) => (
+      <CopyToast
+        onClose={() => toast.dismiss(t.id)}
+        heading={i18n.t("toast.copied")}
+      />
+    ),
+    {
+      duration: 1000,
     }
   );
 };

--- a/src/components/Toasts/ToastController.tsx
+++ b/src/components/Toasts/ToastController.tsx
@@ -130,7 +130,7 @@ export const notifyCopySuccess = () => {
     (t) => (
       <CopyToast
         onClose={() => toast.dismiss(t.id)}
-        heading={i18n.t("toast.copied")}
+        heading={i18n.t("toast.copiedToClipboard")}
       />
     ),
     {

--- a/src/components/TransactionsTab/subcomponents/CopyAddressButton/CopyAdressButton.tsx
+++ b/src/components/TransactionsTab/subcomponents/CopyAddressButton/CopyAdressButton.tsx
@@ -1,7 +1,7 @@
 import { FC, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 
-import writeAddressToClipboard from "../../../../helpers/writeAddressToClipboard";
+import writeTextToClipboard from "../../../../helpers/writeTextToClipboard";
 import selectElement from "../../helpers/selectElement";
 import {
   StyledIcon,
@@ -31,7 +31,7 @@ const CopyAdressButton: FC<CopyAdressButtonProps> = ({ address }) => {
 
   const handleClick = async () => {
     setShowAddress(true);
-    setWriteAddressToClipboardSuccess(await writeAddressToClipboard(address));
+    setWriteAddressToClipboardSuccess(await writeTextToClipboard(address));
   };
 
   if (showAddress) {

--- a/src/helpers/writeTextToClipboard.ts
+++ b/src/helpers/writeTextToClipboard.ts
@@ -1,17 +1,17 @@
-export default async function writeAddressToClipboard(
-  address: string
+export default async function writeTextToClipboard(
+  text: string
 ): Promise<boolean> {
   if (!navigator.clipboard || !navigator.clipboard.writeText) {
     return false;
   }
 
   return await navigator.clipboard
-    .writeText(address)
+    .writeText(text)
     .then(() => {
       return true;
     })
     .catch(() => {
-      console.error("Async: Error copying address to clipboard");
+      console.error("Async: Error copying text to clipboard");
       return false;
     });
 }

--- a/src/styled-components/Pill/Pill.tsx
+++ b/src/styled-components/Pill/Pill.tsx
@@ -25,7 +25,7 @@ export const LargePillButtonStyle = css`
 
   width: fit-content;
   height: 2.5rem;
-  border-radius: 24rem;
+  border-radius: 2.5rem;
 
   &:hover,
   &:focus {

--- a/src/styled-components/Pill/Pill.tsx
+++ b/src/styled-components/Pill/Pill.tsx
@@ -25,6 +25,7 @@ export const LargePillButtonStyle = css`
 
   width: fit-content;
   height: 2.5rem;
+  border-radius: 24rem;
 
   &:hover,
   &:focus {


### PR DESCRIPTION
Fixes #668 

<img width="488" alt="Screen Shot 2022-11-27 at 7 03 32 PM" src="https://user-images.githubusercontent.com/80134686/204167047-152d4934-d23c-46f2-be85-cfb8037e8742.png">
<img width="465" alt="Screen Shot 2022-11-27 at 7 03 24 PM" src="https://user-images.githubusercontent.com/80134686/204167056-d1dac954-9014-4aba-b26f-94934d6596ca.png">

- `LargePillButtonStyled` adjusted to match border radius
- `CopyToast` created and notified on copy success
- fee modal cleaned, `ScrollableContainer` alters some styling so removed until needed
- no fix on vertical alignment, this may be a seperate issue as it appears all of 2xASTs buttons were misaligned, but not recreated on my end.