### PR TITLE
678: Limit decimal places on number inputs to token decimal places

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -197,7 +197,8 @@
     "swapFail": "The swap would fail for the following reasons:",
     "invalidAddress": "{{address}} is an invalid address",
     "invalidValue": "{{address}} is an invalid value",
-    "unknownError": "Unknown error"
+    "unknownError": "Unknown error",
+    "arithmeticUnderflow": "Amount too small"
   },
   "wallet": {
     "connectWallet": "Connect Wallet",

--- a/src/components/ErrorList/helpers/index.ts
+++ b/src/components/ErrorList/helpers/index.ts
@@ -76,6 +76,13 @@ export const getAppErrorTranslation = (error: AppError): ErrorListItemProps => {
     };
   }
 
+  if (error.type === AppErrorType.arithmeticUnderflow) {
+    return {
+      title: AppErrorType.arithmeticUnderflow,
+      text: i18n.t("validatorErrors.arithmeticUnderflow"),
+    };
+  }
+
   return {
     title: AppErrorType.unknownError,
     text: i18n.t("validatorErrors.unknownError"),

--- a/src/components/MakeWidget/subcomponents/ActionButtons/ActionButtons.tsx
+++ b/src/components/MakeWidget/subcomponents/ActionButtons/ActionButtons.tsx
@@ -23,6 +23,7 @@ type ActionButtonsProps = {
   hasMissingMakerToken: boolean;
   hasMissingTakerAmount: boolean;
   hasMissingTakerToken: boolean;
+  hasTokenAmountError: boolean;
   isLoading: boolean;
   networkIsUnsupported: boolean;
   shouldDepositNativeToken: boolean;
@@ -44,6 +45,7 @@ const ActionButtons: FC<ActionButtonsProps> = ({
   hasMissingMakerToken,
   hasMissingTakerAmount,
   hasMissingTakerToken,
+  hasTokenAmountError,
   isLoading,
   networkIsUnsupported,
   shouldDepositNativeToken,
@@ -66,6 +68,7 @@ const ActionButtons: FC<ActionButtonsProps> = ({
       hasMissingTakerAmount ||
       hasMissingTakerToken ||
       takerAddressIsInvalid ||
+      hasTokenAmountError ||
       userIsSigning) &&
     !walletIsNotConnected &&
     !networkIsUnsupported &&

--- a/src/components/SwapInputs/SwapInputs.styles.tsx
+++ b/src/components/SwapInputs/SwapInputs.styles.tsx
@@ -39,8 +39,19 @@ export const SwapIconContainer = styled.div`
   z-index: 1;
 `;
 
-export const StyledTooltip = styled(Tooltip)`
+export const MaxAmountInfoTooltip = styled(Tooltip)`
   position: absolute;
-  bottom: calc(100% + 1rem);
   right: 0;
+`;
+
+export const BaseAmountErrorTooltip = styled(Tooltip)`
+  position: absolute;
+  right: 0;
+`;
+
+export const QuoteAmountErrorTooltip = styled(Tooltip)`
+  position: absolute;
+  right: 0;
+  top: inherit;
+  bottom: 0;
 `;

--- a/src/components/SwapInputs/SwapInputs.tsx
+++ b/src/components/SwapInputs/SwapInputs.tsx
@@ -3,14 +3,18 @@ import { useTranslation } from "react-i18next";
 
 import { TokenInfo } from "@airswap/typescript";
 
+import { AppError } from "../../errors/appError";
 import TokenSelect from "../TokenSelect/TokenSelect";
 import {
+  BaseAmountErrorTooltip,
   Container,
-  StyledTooltip,
+  MaxAmountInfoTooltip,
+  QuoteAmountErrorTooltip,
   SwapIconContainer,
 } from "./SwapInputs.styles";
 import getSwapInputIcon from "./helpers/getSwapInputIcon";
 import getTokenMaxInfoText from "./helpers/getTokenMaxInfoText";
+import useErrorTranslation from "./hooks/useErrorTranslation";
 
 const floatRegExp = new RegExp("^([0-9])*[.,]?([0-9])*$");
 
@@ -26,10 +30,12 @@ const SwapInputs: FC<{
   baseAmount: string;
   baseAmountSubText?: string;
   baseTokenInfo: TokenInfo | null;
+  baseAmountError?: AppError;
   maxAmount: string | null;
   side: "buy" | "sell";
   quoteTokenInfo: TokenInfo | null;
   quoteAmount: string;
+  quoteAmountError?: AppError;
 
   onMaxButtonClick: () => void;
   onChangeTokenClick: (baseOrQuote: "base" | "quote") => void;
@@ -47,9 +53,11 @@ const SwapInputs: FC<{
   baseAmount,
   baseAmountSubText,
   baseTokenInfo,
+  baseAmountError,
   maxAmount = null,
   quoteAmount,
   quoteTokenInfo,
+  quoteAmountError,
   side,
 
   onBaseAmountChange,
@@ -67,6 +75,8 @@ const SwapInputs: FC<{
     [baseTokenInfo, maxAmount, t]
   );
   const isQuote = !!baseAmount && !!quoteAmount && readOnly;
+  const baseAmountErrorText = useErrorTranslation(baseAmountError);
+  const quoteAmountErrorText = useErrorTranslation(quoteAmountError);
 
   const handleTokenAmountChange = (
     e: FormEvent<HTMLInputElement>,
@@ -107,6 +117,7 @@ const SwapInputs: FC<{
         onInfoLabelMouseEnter={handleInfoLabelMouseEnter}
         onInfoLabelMouseLeave={handleInfoLabelMouseLeave}
         readOnly={readOnly}
+        hasError={!!baseAmountError}
         includeAmountInput={isSell || (!!quoteAmount && !isRequesting)}
         selectedToken={isSell ? baseTokenInfo : quoteTokenInfo}
         isLoading={!isSell && isRequesting}
@@ -126,6 +137,7 @@ const SwapInputs: FC<{
           onChangeTokenClick(!isSell ? "base" : "quote");
         }}
         readOnly={readOnly}
+        hasError={!!quoteAmountError}
         includeAmountInput={
           !isSell || canSetQuoteAmount || (!!quoteAmount && !isRequesting)
         }
@@ -137,7 +149,19 @@ const SwapInputs: FC<{
         showMaxInfoButton &&
         showMaxAmountInfo &&
         maxAmountInfoText &&
-        !readOnly && <StyledTooltip>{maxAmountInfoText}</StyledTooltip>}
+        !readOnly && (
+          <MaxAmountInfoTooltip>{maxAmountInfoText}</MaxAmountInfoTooltip>
+        )}
+
+      {baseAmountErrorText && (
+        <BaseAmountErrorTooltip>{baseAmountErrorText}</BaseAmountErrorTooltip>
+      )}
+
+      {quoteAmountErrorText && (
+        <QuoteAmountErrorTooltip>
+          {quoteAmountErrorText}
+        </QuoteAmountErrorTooltip>
+      )}
     </Container>
   );
 };

--- a/src/components/SwapInputs/hooks/useErrorTranslation.ts
+++ b/src/components/SwapInputs/hooks/useErrorTranslation.ts
@@ -1,0 +1,25 @@
+import { useMemo } from "react";
+
+import i18n from "i18next";
+
+import { AppError, AppErrorType } from "../../../errors/appError";
+
+const useErrorTranslation = (error?: AppError): string | undefined => {
+  return useMemo(() => {
+    if (!error) {
+      return undefined;
+    }
+
+    if (error.type === AppErrorType.arithmeticUnderflow) {
+      return i18n.t("validatorErrors.arithmeticUnderflow");
+    }
+
+    if (error.type === AppErrorType.invalidValue) {
+      return i18n.t("validatorErrors.arithmeticUnderflow");
+    }
+
+    return i18n.t("validatorErrors.unknownError");
+  }, [error]);
+};
+
+export default useErrorTranslation;

--- a/src/components/TokenSelect/TokenSelect.tsx
+++ b/src/components/TokenSelect/TokenSelect.tsx
@@ -85,6 +85,7 @@ export type TokenSelectProps = {
    * Used for showing quote style
    */
   isQuote?: boolean;
+  hasError?: boolean;
   subText?: string;
 };
 
@@ -102,6 +103,7 @@ const TokenSelect: FC<TokenSelectProps> = ({
   onAmountChange,
   isLoading = false,
   isQuote = false,
+  hasError = false,
   showMaxButton = false,
   showMaxInfoButton = false,
 }) => {
@@ -140,7 +142,9 @@ const TokenSelect: FC<TokenSelectProps> = ({
               onChange={onAmountChange}
               placeholder="0.00"
             />
-            {!readOnly && <TokenSelectFocusBorder position="right" />}
+            {!readOnly && (
+              <TokenSelectFocusBorder position="right" hasError={hasError} />
+            )}
             {subText && <SubText hasAmount={!!amount}>{subText}</SubText>}
           </AmountAndDetailsContainer>
           {onMaxClicked && showMaxButton && !readOnly && (

--- a/src/components/TokenSelect/subcomponents/TokenSelectFocusBorder/TokenSelectFocusBorder.styles.tsx
+++ b/src/components/TokenSelect/subcomponents/TokenSelectFocusBorder/TokenSelectFocusBorder.styles.tsx
@@ -4,13 +4,14 @@ import convertHexToRGBA from "../../../../helpers/transformHexToRgba";
 
 type BorderType = {
   position: "left" | "right";
+  hasError: boolean;
 };
 
 const Border = styled.div<BorderType>`
   transition: opacity ease-out 0.3s;
   display: block;
   position: absolute;
-  opacity: 0;
+  opacity: ${({ hasError }) => (hasError ? 1 : 0)};
 `;
 
 export const BorderRight = styled(Border)`
@@ -19,7 +20,8 @@ export const BorderRight = styled(Border)`
   left: ${(props) => (props.position === "left" ? 0 : "auto")};
   width: 1px;
   height: 100%;
-  background: ${(props) => props.theme.colors.primary};
+  background: ${({ theme, hasError }) =>
+    hasError ? theme.colors.red : theme.colors.primary};
 `;
 
 export const BorderHorizontal = styled(Border)`
@@ -27,8 +29,12 @@ export const BorderHorizontal = styled(Border)`
   height: 1px;
   background: linear-gradient(
     ${(props) => (props.position === "left" ? "to left" : "to right")},
-    ${(props) => convertHexToRGBA(props.theme.colors.primary, 0)} 0%,
-    ${(props) => convertHexToRGBA(props.theme.colors.primary, 1)} 100%
+    ${({ theme, hasError }) =>
+        convertHexToRGBA(hasError ? theme.colors.red : theme.colors.primary, 0)}
+      0%,
+    ${({ theme, hasError }) =>
+        convertHexToRGBA(hasError ? theme.colors.red : theme.colors.primary, 1)}
+      100%
   );
 `;
 

--- a/src/components/TokenSelect/subcomponents/TokenSelectFocusBorder/TokenSelectFocusBorder.tsx
+++ b/src/components/TokenSelect/subcomponents/TokenSelectFocusBorder/TokenSelectFocusBorder.tsx
@@ -9,17 +9,19 @@ import {
 
 type TokenSelectFocusBorderProps = {
   position?: "left" | "right";
+  hasError?: boolean;
 };
 
 const TokenSelectFocusBorder: FC<TokenSelectFocusBorderProps> = ({
   position = "right",
+  hasError = false,
 }) => {
   return (
     <>
       <GlobalStyle />
-      <BorderRight position={position} />
-      <BorderTop position={position} />
-      <BorderBottom position={position} />
+      <BorderRight position={position} hasError={hasError} />
+      <BorderTop position={position} hasError={hasError} />
+      <BorderBottom position={position} hasError={hasError} />
     </>
   );
 };

--- a/src/errors/appError.ts
+++ b/src/errors/appError.ts
@@ -1,8 +1,10 @@
 import { EthersProjectError } from "./ethersProjectError";
+import { NumericFaultError } from "./numericFaultError";
 import { RpcError } from "./rpcError";
 import { RpcSignRejectedError } from "./rpcSignRejectedError";
 
 export enum AppErrorType {
+  arithmeticUnderflow = "arithmetic-underflow",
   chainDisconnected = "chain-disconnected",
   disconnected = "disconnected",
   expiryPassed = "expiry-passed",
@@ -25,7 +27,11 @@ export enum AppErrorType {
 
 export type AppError = {
   argument?: string;
-  error?: RpcError | RpcSignRejectedError | EthersProjectError;
+  error?:
+    | RpcError
+    | RpcSignRejectedError
+    | EthersProjectError
+    | NumericFaultError;
   type: AppErrorType;
 };
 
@@ -40,7 +46,7 @@ export const isAppError = (x: any): x is AppError => {
 
 export function transformToAppError(
   type: AppErrorType,
-  error?: RpcError | RpcSignRejectedError | EthersProjectError,
+  error?: AppError["error"],
   argument?: string
 ): AppError {
   return {

--- a/src/errors/numericFaultError.ts
+++ b/src/errors/numericFaultError.ts
@@ -1,0 +1,48 @@
+import { AppError, AppErrorType, transformToAppError } from "./appError";
+
+// https://docs.ethers.io/v5/troubleshooting/errors/#help-NUMERIC_FAULT
+
+// Illegal operation with numeric values, like parsing a value with more decimals than the type:
+// utils.parseUnits("1.34", 1);
+// [Error: fractional component exceeds decimals [ See: https://links.ethers.org/v5-errors-NUMERIC_FAULT ]] {
+//   code: 'NUMERIC_FAULT',
+//   fault: 'underflow',
+//   operation: 'parseFixed',
+//   reason: 'fractional component exceeds decimals'
+// }
+
+export interface NumericFaultError {
+  code: "NUMERIC_FAULT";
+  fault: string;
+  operation: string;
+  reason: string;
+  value?: number;
+}
+
+export const isNumericFaultErrorError = (
+  error: any
+): error is NumericFaultError => {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    "fault" in error &&
+    "operation" in error &&
+    "reason" in error &&
+    error.code === "NUMERIC_FAULT"
+  );
+};
+
+export const transformNumericFaultErrorErrorToAppError = (
+  error: NumericFaultError
+): AppError => {
+  if (error.fault === "underflow") {
+    return transformToAppError(
+      AppErrorType.arithmeticUnderflow,
+      error,
+      error.reason
+    );
+  }
+
+  return transformToAppError(AppErrorType.unknownError, error);
+};

--- a/src/errors/transformUnknownErrorToAppError.ts
+++ b/src/errors/transformUnknownErrorToAppError.ts
@@ -3,6 +3,10 @@ import {
   isEthersProjectError,
   transformEthersProjectErrorToAppError,
 } from "./ethersProjectError";
+import {
+  isNumericFaultErrorError,
+  transformNumericFaultErrorErrorToAppError,
+} from "./numericFaultError";
 import { isRpcError, transformRpcErrorToAppError } from "./rpcError";
 import {
   isRpcErrorWithSwapErrorCode,
@@ -21,6 +25,10 @@ const transformUnknownErrorToAppError = (error: any): AppError => {
 
   if (isEthersProjectError(error)) {
     return transformEthersProjectErrorToAppError(error);
+  }
+
+  if (isNumericFaultErrorError(error)) {
+    return transformNumericFaultErrorErrorToAppError(error);
   }
 
   if (isRpcSignRejectedError(error)) {

--- a/src/features/makeOtc/makeOtcActions.ts
+++ b/src/features/makeOtc/makeOtcActions.ts
@@ -1,7 +1,7 @@
 // @ts-ignore
 import * as swapDeploys from "@airswap/swap/deploys.js";
-import { FullOrder, UnsignedOrder } from "@airswap/typescript";
-import { createOrder } from "@airswap/utils";
+import { FullOrder, TokenInfo, UnsignedOrder } from "@airswap/typescript";
+import { createOrder, toAtomicString } from "@airswap/utils";
 import { Web3Provider } from "@ethersproject/providers";
 import { createAsyncThunk } from "@reduxjs/toolkit";
 
@@ -21,6 +21,8 @@ export const createOtcOrder = createAsyncThunk(
     params: {
       chainId: number;
       library: Web3Provider;
+      signerTokenInfo: TokenInfo;
+      senderTokenInfo: TokenInfo;
     } & UnsignedOrder,
     { dispatch }
   ) => {
@@ -42,6 +44,15 @@ export const createOtcOrder = createAsyncThunk(
         return;
       }
 
+      const signerAmount = toAtomicString(
+        params.signerAmount,
+        params.signerTokenInfo.decimals
+      );
+      const senderAmount = toAtomicString(
+        params.senderAmount,
+        params.senderTokenInfo.decimals
+      );
+
       const unsignedOrder = createOrder({
         expiry: params.expiry,
         nonce: Date.now().toString(),
@@ -50,8 +61,8 @@ export const createOtcOrder = createAsyncThunk(
         signerToken: params.signerToken,
         senderToken: params.senderToken,
         protocolFee: "7",
-        signerAmount: params.signerAmount,
-        senderAmount: params.senderAmount,
+        signerAmount,
+        senderAmount,
         chainId: params.chainId,
       });
 

--- a/src/helpers/toAtomicString.ts
+++ b/src/helpers/toAtomicString.ts
@@ -1,0 +1,38 @@
+import { toAtomicString as airswapToAtomicString } from "@airswap/utils";
+
+import { ethers } from "ethers";
+
+import {
+  AppError,
+  AppErrorType,
+  transformToAppError,
+} from "../errors/appError";
+import {
+  isEthersProjectError,
+  transformEthersProjectErrorToAppError,
+} from "../errors/ethersProjectError";
+import {
+  isNumericFaultErrorError,
+  transformNumericFaultErrorErrorToAppError,
+} from "../errors/numericFaultError";
+
+const toAtomicString = (
+  value: string | ethers.BigNumber,
+  decimals: string | number
+): string | AppError => {
+  try {
+    return airswapToAtomicString(value, decimals);
+  } catch (error: any) {
+    if (isNumericFaultErrorError(error)) {
+      return transformNumericFaultErrorErrorToAppError(error);
+    }
+
+    if (isEthersProjectError(error)) {
+      return transformEthersProjectErrorToAppError(error);
+    }
+
+    return transformToAppError(AppErrorType.unknownError, error);
+  }
+};
+
+export default toAtomicString;

--- a/src/hooks/useStringToSignificantDecimals.ts
+++ b/src/hooks/useStringToSignificantDecimals.ts
@@ -1,0 +1,15 @@
+import { useMemo } from "react";
+
+import stringToSignificantDecimals from "../helpers/stringToSignificantDecimals";
+
+const useStringToSignificantDecimals = (
+  input: string,
+  sigDecimals?: number,
+  length?: number
+): string => {
+  return useMemo(() => {
+    return stringToSignificantDecimals(input, sigDecimals, length);
+  }, [input, sigDecimals, length]);
+};
+
+export default useStringToSignificantDecimals;

--- a/src/hooks/useTokenAmountError.ts
+++ b/src/hooks/useTokenAmountError.ts
@@ -1,0 +1,46 @@
+import { useMemo } from "react";
+
+import { TokenInfo } from "@airswap/typescript";
+import { toAtomicString } from "@airswap/utils";
+
+import {
+  AppError,
+  AppErrorType,
+  transformToAppError,
+} from "../errors/appError";
+import {
+  isEthersProjectError,
+  transformEthersProjectErrorToAppError,
+} from "../errors/ethersProjectError";
+import {
+  isNumericFaultErrorError,
+  transformNumericFaultErrorErrorToAppError,
+} from "../errors/numericFaultError";
+
+const useTokenAmountError = (
+  tokenInfo: TokenInfo | null,
+  amount: string
+): AppError | undefined => {
+  return useMemo(() => {
+    if (!tokenInfo || !amount) {
+      return undefined;
+    }
+
+    try {
+      toAtomicString(amount, tokenInfo.decimals);
+      return undefined;
+    } catch (error: any) {
+      if (isNumericFaultErrorError(error)) {
+        return transformNumericFaultErrorErrorToAppError(error);
+      }
+
+      if (isEthersProjectError(error)) {
+        return transformEthersProjectErrorToAppError(error);
+      }
+
+      return transformToAppError(AppErrorType.unknownError, error);
+    }
+  }, [tokenInfo, amount]);
+};
+
+export default useTokenAmountError;

--- a/src/hooks/useTokenAmountError.ts
+++ b/src/hooks/useTokenAmountError.ts
@@ -1,21 +1,9 @@
 import { useMemo } from "react";
 
 import { TokenInfo } from "@airswap/typescript";
-import { toAtomicString } from "@airswap/utils";
 
-import {
-  AppError,
-  AppErrorType,
-  transformToAppError,
-} from "../errors/appError";
-import {
-  isEthersProjectError,
-  transformEthersProjectErrorToAppError,
-} from "../errors/ethersProjectError";
-import {
-  isNumericFaultErrorError,
-  transformNumericFaultErrorErrorToAppError,
-} from "../errors/numericFaultError";
+import { AppError, isAppError } from "../errors/appError";
+import toAtomicString from "../helpers/toAtomicString";
 
 const useTokenAmountError = (
   tokenInfo: TokenInfo | null,
@@ -26,20 +14,9 @@ const useTokenAmountError = (
       return undefined;
     }
 
-    try {
-      toAtomicString(amount, tokenInfo.decimals);
-      return undefined;
-    } catch (error: any) {
-      if (isNumericFaultErrorError(error)) {
-        return transformNumericFaultErrorErrorToAppError(error);
-      }
+    const result = toAtomicString(amount, tokenInfo.decimals);
 
-      if (isEthersProjectError(error)) {
-        return transformEthersProjectErrorToAppError(error);
-      }
-
-      return transformToAppError(AppErrorType.unknownError, error);
-    }
+    return isAppError(result) ? result : undefined;
   }, [tokenInfo, amount]);
 };
 


### PR DESCRIPTION
Fixes #678 

`toAtomicString` throws 2 different errors when passing really small numbers (`invalid decimal value` or `underflow`). Put a wrapper function around it to properly transform these errors to AppError.

This AppError gets passed to SwapInputs and to show error state and tooltip, both errors translate to "Amount is too small".

Also learned a new word: [arithmetic underflow](https://en.wikipedia.org/wiki/Arithmetic_underflow).

https://user-images.githubusercontent.com/86911296/204320491-6e9b7993-87cd-4b30-94b4-9def8ee329b8.mov


