### PR TITLE
TypeError when switching chains

### DIFF
--- a/src/components/TokenSelect/helpers/index.ts
+++ b/src/components/TokenSelect/helpers/index.ts
@@ -10,7 +10,7 @@ export const getTokenText = (
     return "";
   }
 
-  if (token === null) {
+  if (token === null || token === undefined) {
     return i18n.t("common.select");
   }
 

--- a/src/components/TokenSelect/helpers/index.ts
+++ b/src/components/TokenSelect/helpers/index.ts
@@ -10,7 +10,7 @@ export const getTokenText = (
     return "";
   }
 
-  if (token === null || token === undefined) {
+  if (!token) {
     return i18n.t("common.select");
   }
 


### PR DESCRIPTION
If a token does not exist on the switched chain, it becomes undefined. 
This case was treated as the existing one for the null check.