### PR TITLE
725: Improved clearing store when switching between wallets

### DIFF
--- a/src/components/MakeWidget/MakeWidget.tsx
+++ b/src/components/MakeWidget/MakeWidget.tsx
@@ -414,7 +414,7 @@ const MakeWidget: FC = () => {
       />
       <Overlay
         onCloseButtonClick={() => setShowTokenSelectModal(null)}
-        isHidden={!showTokenSelectModal}
+        isHidden={!showTokenSelectModal || !active}
       >
         <TokenList
           activeTokens={activeTokens}

--- a/src/components/MakeWidget/MakeWidget.tsx
+++ b/src/components/MakeWidget/MakeWidget.tsx
@@ -182,6 +182,12 @@ const MakeWidget: FC = () => {
     }
   }, [lastUserOrder, history, dispatch]);
 
+  useEffect(() => {
+    if (!active) {
+      setShowTokenSelectModal(null);
+    }
+  }, [active]);
+
   // Event handlers
   const handleOrderTypeCheckboxChange = (isChecked: boolean) => {
     setOrderType(isChecked ? OrderType.publicListed : OrderType.publicUnlisted);
@@ -414,7 +420,7 @@ const MakeWidget: FC = () => {
       />
       <Overlay
         onCloseButtonClick={() => setShowTokenSelectModal(null)}
-        isHidden={!showTokenSelectModal || !active}
+        isHidden={!showTokenSelectModal}
       >
         <TokenList
           activeTokens={activeTokens}

--- a/src/components/SwapWidget/SwapWidget.tsx
+++ b/src/components/SwapWidget/SwapWidget.tsx
@@ -245,6 +245,12 @@ const SwapWidget: FC = () => {
     [quoteAmount]
   );
 
+  useEffect(() => {
+    if (!active) {
+      setShowTokenSelectModalFor(null);
+    }
+  }, [active]);
+
   const hasSufficientAllowance = (tokenAddress: string | undefined) => {
     if (tokenAddress === nativeCurrency[chainId || 1].address) return true;
     if (!tokenAddress) return false;
@@ -758,7 +764,7 @@ const SwapWidget: FC = () => {
 
       <Overlay
         onCloseButtonClick={() => setShowTokenSelectModalFor(null)}
-        isHidden={!showTokenSelectModalFor || !active}
+        isHidden={!showTokenSelectModalFor}
       >
         <TokenList
           onSelectToken={(newTokenAddress) => {

--- a/src/components/SwapWidget/SwapWidget.tsx
+++ b/src/components/SwapWidget/SwapWidget.tsx
@@ -758,7 +758,7 @@ const SwapWidget: FC = () => {
 
       <Overlay
         onCloseButtonClick={() => setShowTokenSelectModalFor(null)}
-        isHidden={!showTokenSelectModalFor}
+        isHidden={!showTokenSelectModalFor || !active}
       >
         <TokenList
           onSelectToken={(newTokenAddress) => {

--- a/src/components/WalletButton/WalletButton.tsx
+++ b/src/components/WalletButton/WalletButton.tsx
@@ -1,30 +1,30 @@
 import WalletAddress from "./subcomponents/WalletAddress/WalletAddress";
 
 export type WalletButtonProps = {
-  /**
-   * Address of currenlty connected wallet, if any
-   */
-  address?: string | null;
-  setTransactionsTabOpen: (x: boolean) => void;
+  isConnected: boolean;
   isUnsupportedNetwork?: boolean;
+  address?: string | null;
   glow?: boolean;
   setShowWalletList: (x: boolean) => void;
+  setTransactionsTabOpen: (x: boolean) => void;
 };
 
 export const WalletButton = ({
-  address,
-  setTransactionsTabOpen,
+  isConnected,
   isUnsupportedNetwork = false,
-  setShowWalletList,
+  address,
   glow,
+  setShowWalletList,
+  setTransactionsTabOpen,
 }: WalletButtonProps) => {
   return (
     <WalletAddress
+      isConnected={isConnected}
       isUnsupportedNetwork={isUnsupportedNetwork}
       address={address || null}
-      setTransactionsTabOpen={setTransactionsTabOpen}
-      setShowWalletList={setShowWalletList}
       glow={glow}
+      setShowWalletList={setShowWalletList}
+      setTransactionsTabOpen={setTransactionsTabOpen}
     />
   );
 };

--- a/src/components/WalletButton/helpers/index.ts
+++ b/src/components/WalletButton/helpers/index.ts
@@ -1,0 +1,17 @@
+import i18 from "i18next";
+
+export const getWalletButtonText = (
+  isConnected: boolean,
+  isUnsupportedNetwork: boolean,
+  addressOrName: string | null
+): string => {
+  if (isUnsupportedNetwork) {
+    return i18.t("wallet.unsupportedNetwork");
+  }
+
+  if (addressOrName && isConnected) {
+    return addressOrName;
+  }
+
+  return i18.t("wallet.notConnected");
+};

--- a/src/components/WalletButton/subcomponents/WalletAddress/WalletAddress.tsx
+++ b/src/components/WalletButton/subcomponents/WalletAddress/WalletAddress.tsx
@@ -1,6 +1,5 @@
-import { useTranslation } from "react-i18next";
-
 import useAddressOrEnsName from "../../../../hooks/useAddressOrEnsName";
+import { getWalletButtonText } from "../../helpers";
 import {
   ConnectionStatusCircle,
   Button,
@@ -9,33 +8,29 @@ import {
 } from "./WalletAddress.styles";
 
 type WalletAddressPropsType = {
-  address: string | null;
+  isConnected: boolean;
   isUnsupportedNetwork?: boolean;
-  showBlockies?: boolean;
+  address: string | null;
   glow?: boolean;
-  setTransactionsTabOpen: (x: boolean) => void;
   setShowWalletList: (x: boolean) => void;
+  setTransactionsTabOpen: (x: boolean) => void;
 };
 
 const WalletAddress = ({
-  address,
+  isConnected,
   isUnsupportedNetwork = false,
-  setTransactionsTabOpen,
-  setShowWalletList,
+  address,
   glow,
+  setShowWalletList,
+  setTransactionsTabOpen,
 }: WalletAddressPropsType) => {
-  const { t } = useTranslation();
   const addressOrName = useAddressOrEnsName(address);
 
   const renderContent = () => (
     <StyledBorderedButton $glow={glow}>
-      <ConnectionStatusCircle $connected={!!address} />
+      <ConnectionStatusCircle $connected={isConnected} />
       <WalletAddressText>
-        {isUnsupportedNetwork
-          ? t("wallet.unsupportedNetwork")
-          : addressOrName
-          ? addressOrName
-          : t("wallet.notConnected")}
+        {getWalletButtonText(isConnected, isUnsupportedNetwork, addressOrName)}
       </WalletAddressText>
     </StyledBorderedButton>
   );
@@ -43,7 +38,7 @@ const WalletAddress = ({
   return (
     <Button
       onClick={() => {
-        !!address ? setTransactionsTabOpen(true) : setShowWalletList(true);
+        isConnected ? setTransactionsTabOpen(true) : setShowWalletList(true);
       }}
     >
       {renderContent()}

--- a/src/features/balances/balancesSlice.ts
+++ b/src/features/balances/balancesSlice.ts
@@ -11,7 +11,10 @@ import { BigNumber, ethers } from "ethers";
 
 import { AppDispatch, RootState } from "../../app/store";
 import { nativeCurrencyAddress } from "../../constants/nativeCurrency";
-import { setWalletConnected } from "../wallet/walletSlice";
+import {
+  setWalletConnected,
+  setWalletDisconnected,
+} from "../wallet/walletSlice";
 import {
   fetchAllowancesSwap,
   fetchAllowancesWrapper,
@@ -162,9 +165,6 @@ const getSlice = (
     },
     extraReducers: (builder) => {
       builder
-        // Reset to initial state if a new account is connected.
-        .addCase(setWalletConnected, () => initialState)
-
         // Handle requesting balances
         .addCase(asyncThunk.pending, (state) => {
           state.status = "fetching";
@@ -194,7 +194,9 @@ const getSlice = (
         })
         .addCase(asyncThunk.rejected, (state, action) => {
           state.status = "failed";
-        });
+        })
+        .addCase(setWalletConnected, () => initialState)
+        .addCase(setWalletDisconnected, () => initialState);
     },
   });
 };

--- a/src/features/metadata/metadataSlice.ts
+++ b/src/features/metadata/metadataSlice.ts
@@ -190,9 +190,7 @@ export const metadataSlice = createSlice({
           getCustomTokensFromLocalStorage(address, chainId) || [];
         state.tokens.all = getAllTokensFromLocalStorage(chainId);
       })
-      .addCase(setWalletDisconnected, (state) => {
-        state.tokens.active = [];
-      });
+      .addCase(setWalletDisconnected, () => initialState);
   },
 });
 

--- a/src/features/transactions/transactionsSlice.ts
+++ b/src/features/transactions/transactionsSlice.ts
@@ -8,6 +8,10 @@ import {
 import { AppDispatch, RootState } from "../../app/store";
 import { ASSUMED_EXPIRY_NOTIFICATION_BUFFER_MS } from "../../constants/configParams";
 import {
+  setWalletConnected,
+  setWalletDisconnected,
+} from "../wallet/walletSlice";
+import {
   declineTransaction,
   expireTransaction,
   mineTransaction,
@@ -237,6 +241,8 @@ export const transactionsSlice = createSlice({
         protocol: action.payload.protocol,
       });
     });
+    builder.addCase(setWalletConnected, () => initialState);
+    builder.addCase(setWalletDisconnected, () => initialState);
   },
 });
 

--- a/src/features/wallet/Wallet.tsx
+++ b/src/features/wallet/Wallet.tsx
@@ -314,10 +314,11 @@ export const Wallet: FC<WalletPropsType> = ({
           transactionsTabOpen={transactionsTabIsOpen}
         />
         <WalletButton
-          address={account}
+          isConnected={active}
           isUnsupportedNetwork={
             error && error instanceof UnsupportedChainIdError
           }
+          address={account}
           glow={!!pendingTransactions.length}
           setTransactionsTabOpen={() => setTransactionsTabIsOpen(true)}
           setShowWalletList={setShowWalletList}


### PR DESCRIPTION
Fixes #725 

- Improved cleanup of store when switching / disconnecting wallet
- TokenList will close when disconnected
- Fixed wallet button indicator when wallet is not connected.