### PR TITLE
774: Added various styling fixes

### DIFF
--- a/src/components/Dropdown/Dropdown.styles.tsx
+++ b/src/components/Dropdown/Dropdown.styles.tsx
@@ -31,7 +31,7 @@ const ButtonStyle = css`
 export const ItemBackground = styled.div`
   ${ButtonStyle};
 
-  transition: transform 0.2s ease-out;
+  transition: transform 0.2s cubic-bezier(0, 0.76, 0.44, 1.01);
   position: absolute;
   top: var(--dropdown-options-wrapper-padding);
   margin-top: -1px;

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -27,8 +27,6 @@ export type DropdownProps = {
   className?: string;
 };
 
-export const Snavie = "test";
-
 const Dropdown: FC<DropdownProps> = ({
   selectedOption,
   options,

--- a/src/components/MakeWidget/MakeWidget.styles.tsx
+++ b/src/components/MakeWidget/MakeWidget.styles.tsx
@@ -80,8 +80,12 @@ export const StyledReviewApprovalInfo = styled(ReviewApprovalInfo)`
 export const StyledTooltip = styled(Tooltip)`
   position: absolute;
   right: 0;
-  top: 0;
-  height: 3.5rem;
+  top: -5.125rem;
+
+  @media ${breakPoints.tabletLandscapeUp} {
+    top: 0;
+    height: 3.5rem;
+  }
 `;
 
 export const TooltipContainer = styled.div`

--- a/src/components/MakeWidget/MakeWidget.tsx
+++ b/src/components/MakeWidget/MakeWidget.tsx
@@ -51,7 +51,6 @@ import useSufficientAllowance from "../../hooks/useSufficientAllowance";
 import useTokenAddress from "../../hooks/useTokenAddress";
 import useTokenAmountError from "../../hooks/useTokenAmountError";
 import useTokenInfo from "../../hooks/useTokenInfo";
-import useValidAddress from "../../hooks/useValidAddress";
 import { AppRoutes } from "../../routes";
 import { OrderScopeType, OrderType } from "../../types/orderTypes";
 import { TokenSelectModalTypes } from "../../types/tokenSelectModalTypes";
@@ -161,7 +160,6 @@ const MakeWidget: FC = () => {
     !!maxAmount &&
     makerTokenInfo?.address === nativeCurrencyAddress &&
     !!nativeCurrencySafeTransactionFee[makerTokenInfo.chainId];
-  const takerAddressIsValid = useValidAddress(takerAddress);
   const hasApprovalPending = useApprovalPending(makerTokenInfo?.address);
   const shouldDepositNativeTokenAmount =
     useShouldDepositNativeToken(makerAmount);
@@ -441,10 +439,6 @@ const MakeWidget: FC = () => {
           !!web3Error && web3Error instanceof UnsupportedChainIdError
         }
         shouldDepositNativeToken={shouldDepositNativeToken}
-        takerAddressIsInvalid={
-          orderType === OrderType.private &&
-          (!takerAddressIsValid || error?.type === AppErrorType.invalidAddress)
-        }
         userIsSigning={status === "signing"}
         walletIsNotConnected={!active}
         makerTokenSymbol={makerTokenInfo?.symbol}

--- a/src/components/MakeWidget/helpers/index.ts
+++ b/src/components/MakeWidget/helpers/index.ts
@@ -12,7 +12,6 @@ export const getActionButtonTranslation = (
   hasMissingTakerToken: boolean,
   networkIsUnsupported: boolean,
   shouldDepositNativeToken: boolean,
-  takerAddressIsInvalid: boolean,
   walletIsNotConnected: boolean,
   makerTokenSymbol?: string,
   takerTokenSymbol?: string
@@ -51,10 +50,6 @@ export const getActionButtonTranslation = (
 
   if (hasInsufficientAllowance) {
     return `${i18n.t("orders.approve")} ${makerTokenSymbol}`;
-  }
-
-  if (takerAddressIsInvalid) {
-    return i18n.t("orders.enterValidTakerAddress");
   }
 
   return i18n.t("common.sign");

--- a/src/components/MakeWidget/subcomponents/ActionButtons/ActionButtons.tsx
+++ b/src/components/MakeWidget/subcomponents/ActionButtons/ActionButtons.tsx
@@ -27,7 +27,6 @@ type ActionButtonsProps = {
   isLoading: boolean;
   networkIsUnsupported: boolean;
   shouldDepositNativeToken: boolean;
-  takerAddressIsInvalid: boolean;
   userIsSigning: boolean;
   walletIsNotConnected: boolean;
   makerTokenSymbol?: string;
@@ -49,7 +48,6 @@ const ActionButtons: FC<ActionButtonsProps> = ({
   isLoading,
   networkIsUnsupported,
   shouldDepositNativeToken,
-  takerAddressIsInvalid,
   userIsSigning,
   walletIsNotConnected,
   makerTokenSymbol,
@@ -67,7 +65,6 @@ const ActionButtons: FC<ActionButtonsProps> = ({
       hasMissingMakerToken ||
       hasMissingTakerAmount ||
       hasMissingTakerToken ||
-      takerAddressIsInvalid ||
       hasTokenAmountError ||
       userIsSigning) &&
     !walletIsNotConnected &&
@@ -84,7 +81,6 @@ const ActionButtons: FC<ActionButtonsProps> = ({
     hasMissingTakerToken,
     networkIsUnsupported,
     shouldDepositNativeToken,
-    takerAddressIsInvalid,
     walletIsNotConnected,
     makerTokenSymbol,
     takerTokenSymbol

--- a/src/components/MakeWidget/subcomponents/AddressInput/AddressInput.styles.tsx
+++ b/src/components/MakeWidget/subcomponents/AddressInput/AddressInput.styles.tsx
@@ -15,6 +15,7 @@ export const StyledIconButton = styled(IconButton)`
   position: absolute;
   top: 0.825rem;
   right: 0.5rem;
+  color: ${({ theme }) => theme.colors.white};
 `;
 
 export const Input = styled(TextInput)`

--- a/src/components/MyOrdersWidget/subcomponents/Order/Order.tsx
+++ b/src/components/MyOrdersWidget/subcomponents/Order/Order.tsx
@@ -98,7 +98,9 @@ const Order: FC<PropsWithChildren<OrderProps>> = ({
       </StatusIndicator>
       <Text>{`${signerAmount} ${signerTokenInfo?.symbol || ""}`}</Text>
       <Text>{`${senderAmount} ${senderTokenInfo?.symbol || ""}`}</Text>
-      <Text>{timeLeft || orderStatusTranslation}</Text>
+      <Text>
+        {orderStatus === OrderStatus.open ? timeLeft : orderStatusTranslation}
+      </Text>
       <StyledNavLink to={`/${AppRoutes.order}/${orderString}`} />
 
       <ActionButtonContainer>
@@ -107,7 +109,7 @@ const Order: FC<PropsWithChildren<OrderProps>> = ({
         ) : (
           <ActionButton
             icon={orderStatus !== OrderStatus.open ? "bin" : "button-x"}
-            iconSize={orderStatus === OrderStatus.open ? 0.75 : 0.675}
+            iconSize={orderStatus === OrderStatus.open ? 0.5625 : 0.675}
             onClick={handleDeleteOrderButtonClick}
             onMouseEnter={() =>
               onDeleteOrderButtonMouseEnter(

--- a/src/components/OrderDetailWidget/OrderDetailWidget.tsx
+++ b/src/components/OrderDetailWidget/OrderDetailWidget.tsx
@@ -216,6 +216,7 @@ const OrderDetailWidget: FC<OrderDetailWidgetProps> = ({ order }) => {
           />
           <SwapInputs
             readOnly
+            disabled={orderStatus === OrderStatus.canceled}
             isRequestingBaseAmount={isSignerTokenLoading}
             isRequestingBaseToken={isSignerTokenLoading}
             isRequestingQuoteAmount={isSenderTokenLoading}

--- a/src/components/SwapInputs/subcomponents/Tooltip/Tooltip.styles.tsx
+++ b/src/components/SwapInputs/subcomponents/Tooltip/Tooltip.styles.tsx
@@ -9,7 +9,6 @@ export const Container = styled.div`
   display: flex;
   align-items: flex-end;
   max-width: 17rem;
-  width: 100%;
   height: 4.5rem;
 
   @media ${breakPoints.tabletLandscapeUp} {
@@ -18,6 +17,8 @@ export const Container = styled.div`
     right: inherit;
     bottom: inherit;
     left: calc(100% + 1.25rem);
+    width: 100%;
+    height: auto;
   }
 `;
 

--- a/src/components/TokenSelect/TokenSelect.styles.tsx
+++ b/src/components/TokenSelect/TokenSelect.styles.tsx
@@ -174,14 +174,14 @@ export const StyledLabel = styled(FormLabel)`
   text-transform: uppercase;
 `;
 
-export const SubText = styled.div<{ hasAmount: boolean }>`
+export const SubText = styled.div`
   ${quoteTransition};
+
   line-height: 0.75;
   font-size: 0.75rem;
   font-weight: 500;
   text-transform: uppercase;
-  color: ${({ hasAmount, theme }) =>
-    hasAmount ? theme.colors.white : theme.colors.lightGrey};
+  color: ${({ theme }) => theme.colors.lightGrey};
 `;
 
 export const TokenSelectContainer = styled.div<{

--- a/src/components/TokenSelect/TokenSelect.tsx
+++ b/src/components/TokenSelect/TokenSelect.tsx
@@ -160,7 +160,7 @@ const TokenSelect: FC<TokenSelectProps> = ({
             {!readOnly && (
               <TokenSelectFocusBorder position="right" hasError={hasError} />
             )}
-            {subText && <SubText hasAmount={!!amount}>{subText}</SubText>}
+            {subText && <SubText>{subText}</SubText>}
           </AmountAndDetailsContainer>
           {onMaxClicked && showMaxButton && !readOnly && (
             <MaxButton onClick={onMaxClicked}>{t("common.max")}</MaxButton>

--- a/src/style/themes.ts
+++ b/src/style/themes.ts
@@ -192,7 +192,7 @@ export const lightTheme: DefaultTheme = {
     red: "#FF0000",
     orange: "#E7765A",
     green: "#60FF66",
-    placeholderGradient: "linear-gradient(270deg, #E1EBFF 0%, #E1EBFF00 93.3%)",
+    placeholderGradient: "linear-gradient(270deg, #E1EBFF 0%, #E1EBFF 93.3%)",
     darkSubText: "#9EA3AC",
   },
   shadows: {
@@ -201,7 +201,7 @@ export const lightTheme: DefaultTheme = {
     buttonGlow: "0 0 1rem 0rem #FFFFFF",
     buttonGlowFill: "#FFFFFF",
     tooltipGlow: "0.25rem 0.25rem 0.625rem rgba(255, 255, 255, 0.5)",
-    selectOptionsShadow: "0 0.25rem 1.75rem #000000",
+    selectOptionsShadow: "0 0.25rem 1.75rem #E7ECF3",
   },
   typography,
 };

--- a/src/styled-components/Modal/Modal.tsx
+++ b/src/styled-components/Modal/Modal.tsx
@@ -8,8 +8,9 @@ import { sizes } from "../../style/sizes";
 export const ScrollableModalContainer = styled.div`
   ${ScrollBarStyle};
 
-  padding-right: 1.5rem;
+  padding-right: 1rem;
   padding-bottom: 1.5rem;
+  width: calc(100% + 1rem);
   height: calc(100% - ${sizes.tradeContainerPadding});
   overflow-y: auto;
 `;


### PR DESCRIPTION
Fixes #774 

Expiry dropdown

- [x] Has a black drop shadow even in light mode

Counterparty Wallets popover

- [x] Right-side padding is too wide (about double what it should be)

Make screen

- [x] Change fee label color to #6e7686
- [x] For invalid taker address: only show tooltip (don't change button text)

My Orders

- [x] Make the "x" icon smaller within the inline cancel button

Swap

- [x] After order is cancelled display terms at 50% opacity