### PR TITLE
793: Added fix for wrapping native token and missing balances

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -164,7 +164,7 @@
     "selectedServer": "Selected {{serverUrl}} as custom server",
     "settings": "Settings",
     "shouldApproveErc20TokenAmount": "Spending cap must be at least {{amount}} {{symbol}} + {{protocolFee}}% fee",
-    "shouldDepositNativeTokenAmount": "You currently own {{ownedWrappedNativeTokenAmount}} {{wrappedNativeToken}}. You will need to wrap at least",
+    "shouldDepositNativeTokenAmount": "You currently own {{ownedWrappedNativeTokenAmount}} {{wrappedNativeTokenSymbol}}. You will need to wrap at least",
     "specificTaker": "Specific Taker",
     "startByCreatingANewOrder": "Start by creating a new order",
     "submitted": "Transaction Submitted",

--- a/src/components/MakeWidget/MakeWidget.tsx
+++ b/src/components/MakeWidget/MakeWidget.tsx
@@ -40,6 +40,7 @@ import {
   selectUserTokens,
   setUserTokens,
 } from "../../features/userSettings/userSettingsSlice";
+import getWethAddress from "../../helpers/getWethAddress";
 import switchToDefaultChain from "../../helpers/switchToDefaultChain";
 import toMaxAllowedDecimalsNumberString from "../../helpers/toMaxAllowedDecimalsNumberString";
 import useApprovalPending from "../../hooks/useApprovalPending";
@@ -263,11 +264,11 @@ const MakeWidget: FC = () => {
 
     const signerToken =
       makerTokenAddress === nativeCurrencyAddress
-        ? WETH.getAddress(chainId!)
+        ? getWethAddress(chainId!)
         : makerTokenAddress;
     const senderToken =
       takerTokenAddress === nativeCurrencyAddress
-        ? WETH.getAddress(chainId!)
+        ? getWethAddress(chainId!)
         : takerTokenAddress;
 
     setMakerAmount(makerAmount);

--- a/src/components/SwapWidget/SwapWidget.tsx
+++ b/src/components/SwapWidget/SwapWidget.tsx
@@ -84,6 +84,7 @@ import {
   setCustomServerUrl,
   selectCustomServerUrl,
 } from "../../features/userSettings/userSettingsSlice";
+import getWethAddress from "../../helpers/getWethAddress";
 import stringToSignificantDecimals from "../../helpers/stringToSignificantDecimals";
 import switchToDefaultChain from "../../helpers/switchToDefaultChain";
 import useAppRouteParams from "../../hooks/useAppRouteParams";
@@ -381,7 +382,7 @@ const SwapWidget: FC = () => {
     setIsRequestingQuotes(true);
 
     const usesWrapper = swapType === "swapWithWrap";
-    const weth = WETH.getAddress(chainId!);
+    const weth = getWethAddress(chainId!);
     const eth = nativeCurrency[chainId!];
     const _quoteToken = quoteToken === eth.address ? weth : quoteToken!;
     const _baseToken = baseToken === eth.address ? weth : baseToken!;

--- a/src/features/balances/balancesSlice.ts
+++ b/src/features/balances/balancesSlice.ts
@@ -1,3 +1,4 @@
+import { WETH } from "@airswap/libraries";
 import {
   AsyncThunk,
   combineReducers,
@@ -79,11 +80,19 @@ const getThunk: (
     async (params, { getState, dispatch }) => {
       try {
         const state = getState();
+        const { chainId, address } = state.wallet;
+
+        const wrappedNativeCurrencyAddress = chainId
+          ? WETH.getAddress(chainId).toLowerCase()
+          : undefined;
         const activeTokensAddresses = [
           ...state.metadata.tokens.active,
+          ...state.metadata.tokens.custom,
+          ...(wrappedNativeCurrencyAddress
+            ? [wrappedNativeCurrencyAddress]
+            : []),
           nativeCurrencyAddress,
         ];
-        const { chainId, address } = state.wallet;
         dispatch(
           getSetInFlightRequestTokensAction(type)(activeTokensAddresses)
         );

--- a/src/features/balances/balancesSlice.ts
+++ b/src/features/balances/balancesSlice.ts
@@ -12,6 +12,7 @@ import { BigNumber, ethers } from "ethers";
 
 import { AppDispatch, RootState } from "../../app/store";
 import { nativeCurrencyAddress } from "../../constants/nativeCurrency";
+import getWethAddress from "../../helpers/getWethAddress";
 import {
   setWalletConnected,
   setWalletDisconnected,
@@ -83,7 +84,7 @@ const getThunk: (
         const { chainId, address } = state.wallet;
 
         const wrappedNativeCurrencyAddress = chainId
-          ? WETH.getAddress(chainId).toLowerCase()
+          ? getWethAddress(chainId)
           : undefined;
         const activeTokensAddresses = [
           ...state.metadata.tokens.active,

--- a/src/features/gasCost/gasCostApi.ts
+++ b/src/features/gasCost/gasCostApi.ts
@@ -5,6 +5,7 @@ import { TokenInfo } from "@airswap/types";
 import { BigNumber } from "bignumber.js";
 import { Contract, providers, BigNumber as EthersBigNumber } from "ethers";
 
+import getWethAddress from "../../helpers/getWethAddress";
 import uniswapFactoryAbi from "../../uniswap/abis/factory.json";
 import uniswapPairAbi from "../../uniswap/abis/pair.json";
 import uniswapDeploys from "../../uniswap/deployments";
@@ -33,7 +34,7 @@ const getPriceOfTokenInWethFromUniswap: (
   chainId: number
 ) => Promise<BigNumber> = async (tokenInfo, provider, chainId) => {
   const tokenAddress = tokenInfo.address;
-  const wethAddress = WETH.getAddress(chainId);
+  const wethAddress = getWethAddress(chainId);
   if (tokenAddress === wethAddress || tokenAddress === ADDRESS_ZERO)
     return new BigNumber(1);
 

--- a/src/features/metadata/metadataSlice.ts
+++ b/src/features/metadata/metadataSlice.ts
@@ -137,13 +137,26 @@ export const metadataSlice = createSlice({
       })
       .addCase(fetchAllTokens.fulfilled, (state, action) => {
         const { payload: tokenInfo } = action;
-        const all = tokenInfo.reduce(
-          (allTokens: { [address: string]: TokenInfo }, token) => {
-            const { address } = token;
+        const newAllTokens = tokenInfo.reduce(
+          (allTokens: MetadataTokens["all"], token) => {
+            const address = token.address.toLowerCase();
             if (!allTokens[address]) {
-              allTokens[address] = { ...token };
+              allTokens[address] = {
+                ...token,
+                address: token.address.toLowerCase(),
+              };
             }
             return allTokens;
+          },
+          {}
+        );
+
+        const stateAllTokens = Object.keys(state.tokens.all).reduce(
+          (allTokens: MetadataTokens["all"], token) => {
+            return {
+              ...allTokens,
+              [token.toLowerCase()]: state.tokens.all[token],
+            };
           },
           {}
         );
@@ -151,8 +164,8 @@ export const metadataSlice = createSlice({
         const tokens = {
           ...state.tokens,
           all: {
-            ...state.tokens.all,
-            ...all,
+            ...stateAllTokens,
+            ...newAllTokens,
           },
         };
 

--- a/src/features/orders/ordersSlice.ts
+++ b/src/features/orders/ordersSlice.ts
@@ -24,6 +24,7 @@ import {
 import nativeCurrency from "../../constants/nativeCurrency";
 import { AppError, AppErrorType, isAppError } from "../../errors/appError";
 import transformUnknownErrorToAppError from "../../errors/transformUnknownErrorToAppError";
+import getWethAddress from "../../helpers/getWethAddress";
 import toRoundedAtomicString from "../../helpers/toRoundedAtomicString";
 import {
   allowancesSwapActions,
@@ -79,9 +80,9 @@ const initialState: OrdersState = {
 // replaces WETH to ETH on Wrapper orders
 const refactorOrder = (order: OrderERC20, chainId: number) => {
   let newOrder = { ...order };
-  if (order.senderToken === WETH.getAddress(chainId)) {
+  if (order.senderToken === getWethAddress(chainId)) {
     newOrder.senderToken = nativeCurrency[chainId].address;
-  } else if (order.signerToken === WETH.getAddress(chainId)) {
+  } else if (order.signerToken === getWethAddress(chainId)) {
     newOrder.signerToken = nativeCurrency[chainId].address;
   }
   return newOrder;
@@ -129,7 +130,7 @@ export const deposit = createAsyncThunk(
         const transaction: SubmittedDepositOrder = {
           type: "Deposit",
           order: {
-            signerToken: WETH.getAddress(params.chainId),
+            signerToken: getWethAddress(params.chainId),
             signerAmount: senderAmount,
             senderToken: nativeCurrency[params.chainId].address,
             senderAmount: senderAmount,
@@ -216,7 +217,7 @@ export const withdraw = createAsyncThunk(
               params.senderAmount,
               params.senderTokenDecimals
             ),
-            senderToken: WETH.getAddress(params.chainId),
+            senderToken: getWethAddress(params.chainId),
             senderAmount: toAtomicString(
               params.senderAmount,
               params.senderTokenDecimals

--- a/src/helpers/getWethAddress.ts
+++ b/src/helpers/getWethAddress.ts
@@ -1,0 +1,7 @@
+import { WETH } from "@airswap/libraries";
+
+const getWethAddress = (chainId: number): string => {
+  return WETH.getAddress(chainId).toLowerCase();
+};
+
+export default getWethAddress;

--- a/src/hooks/useApprovalPending.ts
+++ b/src/hooks/useApprovalPending.ts
@@ -7,6 +7,7 @@ import { useWeb3React } from "@web3-react/core";
 import { useAppSelector } from "../app/hooks";
 import { nativeCurrencyAddress } from "../constants/nativeCurrency";
 import { selectPendingApprovals } from "../features/transactions/transactionsSlice";
+import getWethAddress from "../helpers/getWethAddress";
 
 const useApprovalPending = (tokenAddress?: string | null): boolean => {
   const { chainId } = useWeb3React<Web3Provider>();
@@ -20,7 +21,7 @@ const useApprovalPending = (tokenAddress?: string | null): boolean => {
     // ETH can't have approvals because it's not a token. So we default to WETH.
     const justifiedAddress =
       tokenAddress === nativeCurrencyAddress
-        ? WETH.getAddress(chainId)
+        ? getWethAddress(chainId)
         : tokenAddress;
 
     return pendingApprovals.some((tx) => tx.tokenAddress === justifiedAddress);

--- a/src/hooks/useNativeWrappedToken.ts
+++ b/src/hooks/useNativeWrappedToken.ts
@@ -16,7 +16,8 @@ const useNativeWrappedToken = (chainId?: number): TokenInfo | null => {
 
     return (
       allTokens.find(
-        (tokenInfo) => tokenInfo.address === WETH.getAddress(chainId)
+        (tokenInfo) =>
+          tokenInfo.address === WETH.getAddress(chainId).toLowerCase()
       ) || null
     );
   }, [allTokens, chainId]);

--- a/src/hooks/useNativeWrappedToken.ts
+++ b/src/hooks/useNativeWrappedToken.ts
@@ -5,6 +5,7 @@ import { TokenInfo } from "@airswap/types";
 
 import { useAppSelector } from "../app/hooks";
 import { selectAllTokenInfo } from "../features/metadata/metadataSlice";
+import getWethAddress from "../helpers/getWethAddress";
 
 const useNativeWrappedToken = (chainId?: number): TokenInfo | null => {
   const allTokens = useAppSelector(selectAllTokenInfo);
@@ -16,8 +17,7 @@ const useNativeWrappedToken = (chainId?: number): TokenInfo | null => {
 
     return (
       allTokens.find(
-        (tokenInfo) =>
-          tokenInfo.address === WETH.getAddress(chainId).toLowerCase()
+        (tokenInfo) => tokenInfo.address === getWethAddress(chainId)
       ) || null
     );
   }, [allTokens, chainId]);

--- a/src/hooks/useShouldDepositNativeTokenAmount.ts
+++ b/src/hooks/useShouldDepositNativeTokenAmount.ts
@@ -55,13 +55,8 @@ const useShouldDepositNativeTokenAmount = (
       activeTokens,
       chainId
     );
-    const wrappedTokenInfo = findEthOrTokenByAddress(
-      wrappedTokenAddress,
-      activeTokens,
-      chainId
-    );
 
-    if (!nativeTokenInfo || !wrappedTokenInfo) {
+    if (!nativeTokenInfo || !wrappedNativeToken) {
       return undefined;
     }
 
@@ -69,7 +64,7 @@ const useShouldDepositNativeTokenAmount = (
       10 ** nativeTokenInfo.decimals
     );
     const wrappedTokenBigNumber = new BigNumber(wrappedTokenBalance).div(
-      10 ** wrappedTokenInfo.decimals
+      10 ** wrappedNativeToken.decimals
     );
     const tokenAmountBigNumber = new BigNumber(
       toAtomicString(tokenAmount, nativeTokenInfo.decimals)

--- a/src/hooks/useShouldDepositNativeTokenAmountInfo.ts
+++ b/src/hooks/useShouldDepositNativeTokenAmountInfo.ts
@@ -11,6 +11,7 @@ import { nativeCurrencyAddress } from "../constants/nativeCurrency";
 import { selectBalances } from "../features/balances/balancesSlice";
 import { selectAllTokenInfo } from "../features/metadata/metadataSlice";
 import findEthOrTokenByAddress from "../helpers/findEthOrTokenByAddress";
+import getWethAddress from "../helpers/getWethAddress";
 import stringToSignificantDecimals from "../helpers/stringToSignificantDecimals";
 
 interface DepositNativeTokenAmountInfo {
@@ -37,7 +38,7 @@ const useShouldDepositNativeTokenAmountInfo =
         return;
       }
 
-      const wrappedTokenAddress = WETH.getAddress(chainId);
+      const wrappedTokenAddress = getWethAddress(chainId);
 
       if (!wrappedTokenAddress) {
         return;

--- a/src/hooks/useSufficientAllowance.ts
+++ b/src/hooks/useSufficientAllowance.ts
@@ -29,7 +29,7 @@ const useSufficientAllowance = (
     // ETH can't have allowance because it's not a token. So we default to WETH.
     const justifiedAddress =
       token.address === nativeCurrencyAddress
-        ? WETH.getAddress(chainId)
+        ? WETH.getAddress(chainId).toLowerCase()
         : token.address;
 
     const justifiedToken = findEthOrTokenByAddress(

--- a/src/hooks/useSufficientAllowance.ts
+++ b/src/hooks/useSufficientAllowance.ts
@@ -12,6 +12,7 @@ import { nativeCurrencyAddress } from "../constants/nativeCurrency";
 import { selectAllowances } from "../features/balances/balancesSlice";
 import { selectAllTokenInfo } from "../features/metadata/metadataSlice";
 import findEthOrTokenByAddress from "../helpers/findEthOrTokenByAddress";
+import getWethAddress from "../helpers/getWethAddress";
 
 const useSufficientAllowance = (
   token: TokenInfo | null,
@@ -29,7 +30,7 @@ const useSufficientAllowance = (
     // ETH can't have allowance because it's not a token. So we default to WETH.
     const justifiedAddress =
       token.address === nativeCurrencyAddress
-        ? WETH.getAddress(chainId).toLowerCase()
+        ? getWethAddress(chainId)
         : token.address;
 
     const justifiedToken = findEthOrTokenByAddress(

--- a/src/hooks/useSwapType.ts
+++ b/src/hooks/useSwapType.ts
@@ -6,6 +6,7 @@ import { Web3Provider } from "@ethersproject/providers";
 import { useWeb3React } from "@web3-react/core";
 
 import nativeCurrency from "../constants/nativeCurrency";
+import getWethAddress from "../helpers/getWethAddress";
 import { SwapType } from "../types/swapType";
 
 const useSwapType = (
@@ -20,7 +21,7 @@ const useSwapType = (
     }
 
     const eth = nativeCurrency[chainId].address;
-    const weth = WETH.getAddress(chainId);
+    const weth = getWethAddress(chainId);
 
     if (
       [weth, eth].includes(token1.address) &&


### PR DESCRIPTION
Fixes #793 

Fixes wrapping ETH for Maker and Taker side. Will do last fixes and testing later today.

- WETH.getAddress() returns address that's not lower case. So it failed to match the correct address in several places.
- Allowances and balances only accounting for active tokens. It will now automatically add WETH and other custom tokens.

https://github.com/airswap/airswap-web/assets/86911296/92ce9598-a4fb-4477-828a-d274ba6a1a0a

https://github.com/airswap/airswap-web/assets/86911296/468c4c81-b4f7-4fae-990b-572681f9993a



