### PR TITLE
728: Added fallback when copy to clipboard fails

### DIFF
--- a/src/components/OrderDetailWidget/OrderDetailWidget.tsx
+++ b/src/components/OrderDetailWidget/OrderDetailWidget.tsx
@@ -37,7 +37,6 @@ import {
   setErrors,
 } from "../../features/takeOtc/takeOtcSlice";
 import switchToDefaultChain from "../../helpers/switchToDefaultChain";
-import writeTextToClipboard from "../../helpers/writeTextToClipboard";
 import useApprovalPending from "../../hooks/useApprovalPending";
 import useDepositPending from "../../hooks/useDepositPending";
 import useInsufficientBalance from "../../hooks/useInsufficientBalance";
@@ -52,7 +51,6 @@ import { ErrorList } from "../ErrorList/ErrorList";
 import ProtocolFeeModal from "../InformationModals/subcomponents/ProtocolFeeModal/ProtocolFeeModal";
 import Overlay from "../Overlay/Overlay";
 import SwapInputs from "../SwapInputs/SwapInputs";
-import { notifyCopySuccess, notifyError } from "../Toasts/ToastController";
 import {
   Container,
   StyledActionButtons,
@@ -188,13 +186,6 @@ const OrderDetailWidget: FC<OrderDetailWidgetProps> = ({ order }) => {
     });
   };
 
-  const handleCopyButtonClick = async () => {
-    const copy = await writeTextToClipboard(window.location.toString());
-    copy
-      ? notifyCopySuccess()
-      : notifyError({ heading: t("toast.copyFailed"), cta: "" });
-  };
-
   const takeOrder = async () => {
     if (!library) return;
     const errors = await check(
@@ -319,7 +310,6 @@ const OrderDetailWidget: FC<OrderDetailWidgetProps> = ({ order }) => {
             rate={tokenExchangeRate}
             onViewAllQuotesButtonClick={toggleShowViewAllQuotes}
             onFeeButtonClick={toggleShowFeeInfo}
-            onCopyButtonClick={handleCopyButtonClick}
           />
           <StyledInfoSection
             isExpired={orderStatus === OrderStatus.expired}

--- a/src/components/OrderDetailWidget/subcomponents/CopyLinkButton/CopyLinkButton.styles.tsx
+++ b/src/components/OrderDetailWidget/subcomponents/CopyLinkButton/CopyLinkButton.styles.tsx
@@ -1,0 +1,19 @@
+import styled from "styled-components/macro";
+
+import { TextEllipsis } from "../../../../style/mixins";
+import { LargePillButton } from "../../../../styled-components/Pill/Pill";
+
+export const CopyLinkElement = styled(LargePillButton)`
+  ${TextEllipsis};
+
+  display: inline;
+  line-height: 3;
+  width: 100%;
+  max-width: 15rem;
+  padding-right: 1rem;
+
+  &::selection {
+    color: ${(props) => props.theme.colors.white};
+    background: ${(props) => props.theme.colors.primary};
+  }
+`;

--- a/src/components/OrderDetailWidget/subcomponents/CopyLinkButton/CopyLinkButton.tsx
+++ b/src/components/OrderDetailWidget/subcomponents/CopyLinkButton/CopyLinkButton.tsx
@@ -1,0 +1,74 @@
+import React, {
+  FC,
+  ReactElement,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { useTranslation } from "react-i18next";
+
+import writeTextToClipboard from "../../../../helpers/writeTextToClipboard";
+import { LargePillButton } from "../../../../styled-components/Pill/Pill";
+import Icon from "../../../Icon/Icon";
+import { notifyCopySuccess } from "../../../Toasts/ToastController";
+import { CopyLinkElement } from "./CopyLinkButton.styles";
+
+interface CopyLinkButtonProps {
+  className?: string;
+}
+
+const CopyLinkButton: FC<CopyLinkButtonProps> = ({
+  className = "",
+}): ReactElement => {
+  const { t } = useTranslation();
+  const copyLinkElement = useRef<HTMLDivElement>(null);
+
+  const [showFallback, setShowFallback] = useState(false);
+  const location = useMemo(() => window.location.toString(), []);
+
+  const handleCopyButtonClick = async () => {
+    const isCopySuccess = await writeTextToClipboard(location);
+
+    if (!isCopySuccess) {
+      setShowFallback(true);
+
+      return;
+    }
+
+    notifyCopySuccess();
+  };
+
+  useEffect(() => {
+    if (!copyLinkElement.current) {
+      return;
+    }
+
+    const range = document.createRange();
+    range.selectNode(copyLinkElement.current);
+    window.getSelection()?.removeAllRanges();
+    window.getSelection()?.addRange(range);
+  }, [showFallback]);
+
+  if (showFallback) {
+    return (
+      <CopyLinkElement
+        as="div"
+        id="snavie"
+        ref={copyLinkElement}
+        className={className}
+      >
+        {location}
+      </CopyLinkElement>
+    );
+  }
+
+  return (
+    <LargePillButton onClick={handleCopyButtonClick} className={className}>
+      {t("orders.copyLink")}
+      <Icon name="copy2" />
+    </LargePillButton>
+  );
+};
+
+export default CopyLinkButton;

--- a/src/components/OrderDetailWidget/subcomponents/InfoButtons/InfoButtons.styles.tsx
+++ b/src/components/OrderDetailWidget/subcomponents/InfoButtons/InfoButtons.styles.tsx
@@ -1,6 +1,7 @@
 import styled from "styled-components/macro";
 
 import { LargePillButton } from "../../../../styled-components/Pill/Pill";
+import CopyLinkButton from "../CopyLinkButton/CopyLinkButton";
 
 export const Container = styled.div`
   display: flex;
@@ -15,7 +16,8 @@ export const ButtonsWrapper = styled.div`
   align-items: center;
   flex-wrap: wrap;
 
-  > button {
+  > button,
+  > div {
     margin-bottom: 1rem;
   }
 `;
@@ -24,10 +26,6 @@ export const StyledLargePillButton = styled(LargePillButton)`
   margin: 0 0.5rem;
 `;
 
-export const InfoText = styled.div`
-  color: ${({ theme }) =>
-    theme.name === "dark" ? theme.colors.white : theme.colors.primary};
-  width: 100%;
-  text-align: center;
-  margin-bottom: 1rem;
+export const StyledCopyLinkButton = styled(CopyLinkButton)`
+  margin: 0 0.5rem;
 `;

--- a/src/components/OrderDetailWidget/subcomponents/InfoButtons/InfoButtons.tsx
+++ b/src/components/OrderDetailWidget/subcomponents/InfoButtons/InfoButtons.tsx
@@ -10,6 +10,7 @@ import { RateField } from "../../../MakeWidget/subcomponents/RateField/RateField
 import {
   ButtonsWrapper,
   Container,
+  StyledCopyLinkButton,
   StyledLargePillButton,
 } from "./InfoButtons.styles";
 
@@ -21,7 +22,6 @@ type InfoButtonsProps = {
   rate: BigNumber;
   onViewAllQuotesButtonClick: () => void;
   onFeeButtonClick: () => void;
-  onCopyButtonClick: () => void;
   className?: string;
 };
 
@@ -33,7 +33,6 @@ const InfoButtons: FC<InfoButtonsProps> = ({
   rate,
   onViewAllQuotesButtonClick,
   onFeeButtonClick,
-  onCopyButtonClick,
   className,
 }) => {
   const { t } = useTranslation();
@@ -51,12 +50,7 @@ const InfoButtons: FC<InfoButtonsProps> = ({
             <Icon name="information-circle-outline" />
           </StyledLargePillButton>
         )}
-        {isMakerOfSwap && (
-          <StyledLargePillButton onClick={onCopyButtonClick}>
-            {t("orders.copyLink")}
-            <Icon name="copy2" />
-          </StyledLargePillButton>
-        )}
+        {isMakerOfSwap && <StyledCopyLinkButton />}
         {showViewAllQuotes && (
           <StyledLargePillButton onClick={onViewAllQuotesButtonClick}>
             {t("orders.viewAllQuotes")}


### PR DESCRIPTION
Fixes #728 

When copy to clipboard fails the copy button is replaced with a div element that's automatically selected so the user can manually copy the link.

https://github.com/airswap/airswap-web/assets/86911296/ed5e3eaf-cee1-4671-bb51-3709348ddc86

