### PR TITLE
834: Fixed RFQ errors when swapping from and to native token

### DIFF
--- a/src/components/SwapWidget/SwapWidget.tsx
+++ b/src/components/SwapWidget/SwapWidget.tsx
@@ -542,20 +542,10 @@ const SwapWidget: FC = () => {
         bestTradeOption!.order!,
         senderWallet,
         chainId || 1,
-        library
+        library,
+        swapType === "swapWithWrap"
       );
 
-      // If swapping with wrapper then ignore sender errors.
-      if (swapType === "swapWithWrap") {
-        for (let i = errors.length - 1; i >= 0; i--) {
-          if (
-            errors[i].type === AppErrorType.senderAllowanceLow ||
-            errors[i].type === AppErrorType.senderBalanceLow
-          ) {
-            errors.splice(i, 1);
-          }
-        }
-      }
       if (errors.length) {
         dispatch(setErrors(errors));
         setIsSwapping(false);

--- a/src/hooks/useSwapType.ts
+++ b/src/hooks/useSwapType.ts
@@ -30,7 +30,7 @@ const useSwapType = (
       return "wrapOrUnwrap";
     }
 
-    if ([token1.address, token2.address].includes(eth)) {
+    if ([token1.address].includes(eth)) {
       return "swapWithWrap";
     }
 


### PR DESCRIPTION
Fixes #834 

https://github.com/airswap/airswap-web/assets/86911296/5984bcdb-e575-4677-9701-ef9010e36cd0

https://goerli.etherscan.io/tx/0x1ecde9aa417cdee6f33d0528dfecaa5070f74de2b2e0911241a9fa131e8ca267

Also fixed bug when swapping from ERC20 to ETH. Which is actually WETH, that's why we need to implement the review screen for RFQ later (#831).