### PR TITLE
Fix `toMaxAllowedDecimalsNumberString`

### DIFF
--- a/src/components/@widgets/MakeWidget/MakeWidget.tsx
+++ b/src/components/@widgets/MakeWidget/MakeWidget.tsx
@@ -46,6 +46,7 @@ import {
 import getWethAddress from "../../../helpers/getWethAddress";
 import switchToDefaultChain from "../../../helpers/switchToDefaultChain";
 import toMaxAllowedDecimalsNumberString from "../../../helpers/toMaxAllowedDecimalsNumberString";
+import toRoundedNumberString from "../../../helpers/toRoundedNumberString";
 import useAllowance from "../../../hooks/useAllowance";
 import useApprovalPending from "../../../hooks/useApprovalPending";
 import useDepositPending from "../../../hooks/useDepositPending";
@@ -257,6 +258,18 @@ const MakeWidget: FC = () => {
       return;
     }
 
+    const formattedMakerAmount = toRoundedNumberString(
+      makerAmount,
+      makerTokenInfo?.decimals
+    );
+    const formattedTakerAmount = toRoundedNumberString(
+      takerAmount,
+      takerTokenInfo?.decimals
+    );
+
+    setMakerAmount(formattedMakerAmount);
+    setTakerAmount(formattedTakerAmount);
+
     setState(MakeWidgetState.review);
   };
 
@@ -273,9 +286,6 @@ const MakeWidget: FC = () => {
       takerTokenAddress === nativeCurrencyAddress
         ? getWethAddress(chainId!)
         : takerTokenAddress;
-
-    setMakerAmount(makerAmount);
-    setTakerAmount(takerAmount);
 
     dispatch(
       createOtcOrder({


### PR DESCRIPTION
This PR fixes [a problem an OTC maker was having](https://discord.com/channels/590643190281928738/599315389327081492/1147978174253236366) whereby they couldn't sign their order.

They have tried to enter a number of decimals that is unsupported by the tokens, so the parse is failing.

The UI does already have a check function for this `toMaxAllowedDecimalsNumberString`, but for some reason this function ignores numbers > 1.

I've updated the function & test.