### PR TITLE
891: Fix LastLook expired transactions

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "tls-browserify": "^0.2.2",
     "truncate-eth-address": "^1.0.2",
     "typescript": "^4.4.3",
+    "usehooks-ts": "^3.1.0",
     "zlib-browserify": "^0.0.3"
   },
   "devDependencies": {

--- a/src/components/@widgets/OrderDetailWidget/hooks/useSessionOrderTransaction.ts
+++ b/src/components/@widgets/OrderDetailWidget/hooks/useSessionOrderTransaction.ts
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from "react";
 
 import { useAppSelector } from "../../../../app/hooks";
 import { SubmittedTransaction } from "../../../../entities/SubmittedTransaction/SubmittedTransaction";
+import { isSubmittedOrder } from "../../../../entities/SubmittedTransaction/SubmittedTransactionHelpers";
 import { selectOrderTransactions } from "../../../../features/transactions/transactionsSlice";
 import { TransactionStatusType } from "../../../../types/transactionTypes";
 
@@ -21,7 +22,8 @@ const useSessionOrderTransaction = (
     }
 
     if (
-      transactions[0].nonce === nonce &&
+      isSubmittedOrder(transactions[0]) &&
+      transactions[0].order.nonce === nonce &&
       transactions[0].status === TransactionStatusType.processing
     ) {
       setProcessingTransactionHash(transactions[0].hash);

--- a/src/components/@widgets/SwapWidget/SwapWidget.tsx
+++ b/src/components/@widgets/SwapWidget/SwapWidget.tsx
@@ -30,7 +30,6 @@ import nativeCurrency, {
 } from "../../../constants/nativeCurrency";
 import { InterfaceContext } from "../../../contexts/interface/Interface";
 import { LastLookContext } from "../../../contexts/lastLook/LastLook";
-import { ProtocolType } from "../../../entities/SubmittedTransaction/SubmittedTransaction";
 import { AppErrorType } from "../../../errors/appError";
 import transformUnknownErrorToAppError from "../../../errors/transformUnknownErrorToAppError";
 import {
@@ -671,10 +670,10 @@ const SwapWidget: FC = () => {
   ]);
 
   const takeBestOption = async () => {
-    if (bestTradeOption!.protocol === "request-for-quote-erc20") {
-      await swapWithRequestForQuote();
-    } else {
+    if (bestTradeOption?.isLastLook) {
       await swapWithLastLook();
+    } else {
+      await swapWithRequestForQuote();
     }
   };
 
@@ -809,10 +808,10 @@ const SwapWidget: FC = () => {
     <>
       <StyledSwapWidget>
         <SwapWidgetHeader
+          isLastLook={!!bestTradeOption?.isLastLook}
           title={isApproving ? t("orders.approve") : t("common.rfq")}
           isQuote={!isRequestingQuotes && !showOrderSubmitted}
           onGasFreeTradeButtonClick={() => setShowGasFeeInfo(true)}
-          protocol={bestTradeOption?.protocol as ProtocolType}
           expiry={bestTradeOption?.order?.expiry}
         />
         {!isApproving && !isSwapping && !showOrderSubmitted && (

--- a/src/components/@widgets/SwapWidget/SwapWidget.tsx
+++ b/src/components/@widgets/SwapWidget/SwapWidget.tsx
@@ -591,28 +591,15 @@ const SwapWidget: FC = () => {
         setIsSwapping(false);
         return;
       }
-      const accepted = await LastLook.sendOrderForConsideration({
-        locator: bestTradeOption!.pricing!.locator,
-        order: order,
-      });
-      setIsSwapping(false);
-      if (accepted) {
-        setShowOrderSubmitted(true);
-        LastLook.unsubscribeAllServers();
-      } else {
-        notifyError({
-          heading: t("orders.swapRejected"),
-          cta: t("orders.swapRejectedCallToAction"),
-        });
 
-        dispatch(
-          declineTransaction({
-            signerWallet: order.signerWallet,
-            nonce: order.nonce,
-            reason: "Pricing expired",
-          })
-        );
-      }
+      // LastLook.sendOrderForConsideration({
+      //   locator: bestTradeOption!.pricing!.locator,
+      //   order: order,
+      // });
+
+      setIsSwapping(false);
+      setShowOrderSubmitted(true);
+      LastLook.unsubscribeAllServers();
     } catch (e: any) {
       setIsSwapping(false);
       dispatch(clearTradeTermsQuoteAmount());

--- a/src/components/@widgets/SwapWidget/SwapWidget.tsx
+++ b/src/components/@widgets/SwapWidget/SwapWidget.tsx
@@ -592,10 +592,10 @@ const SwapWidget: FC = () => {
         return;
       }
 
-      // LastLook.sendOrderForConsideration({
-      //   locator: bestTradeOption!.pricing!.locator,
-      //   order: order,
-      // });
+      LastLook.sendOrderForConsideration({
+        locator: bestTradeOption!.pricing!.locator,
+        order: order,
+      });
 
       setIsSwapping(false);
       setShowOrderSubmitted(true);
@@ -795,7 +795,7 @@ const SwapWidget: FC = () => {
     <>
       <StyledSwapWidget>
         <SwapWidgetHeader
-          isLastLook={!!bestTradeOption?.isLastLook}
+          isLastLook={!!(bestTradeOption && bestTradeOption.isLastLook)}
           title={isApproving ? t("orders.approve") : t("common.rfq")}
           isQuote={!isRequestingQuotes && !showOrderSubmitted}
           onGasFreeTradeButtonClick={() => setShowGasFeeInfo(true)}

--- a/src/components/@widgets/SwapWidget/subcomponents/SwapWidgetHeader/SwapWidgetHeader.tsx
+++ b/src/components/@widgets/SwapWidget/subcomponents/SwapWidgetHeader/SwapWidgetHeader.tsx
@@ -2,7 +2,6 @@ import { FC, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 
 import { RFQ_EXPIRY_BUFFER_MS } from "../../../../../constants/configParams";
-import { ProtocolType } from "../../../../../entities/SubmittedTransaction/SubmittedTransaction";
 import { WidgetHeader } from "../../../../../styled-components/WidgetHeader/WidgetHeader";
 import { Title } from "../../../../Typography/Typography";
 import {
@@ -14,18 +13,18 @@ import {
 } from "./SwapWidgetHeader.styles";
 
 interface SwapWidgetHeaderProps {
+  isLastLook: boolean;
   title: string;
   isQuote: boolean;
   onGasFreeTradeButtonClick: () => void;
-  protocol?: ProtocolType;
   expiry?: string;
 }
 
 const SwapWidgetHeader: FC<SwapWidgetHeaderProps> = ({
+  isLastLook,
   title,
   isQuote,
   onGasFreeTradeButtonClick,
-  protocol,
   expiry,
 }) => {
   const { t } = useTranslation();
@@ -40,14 +39,14 @@ const SwapWidgetHeader: FC<SwapWidgetHeaderProps> = ({
         {title}
       </Title>
 
-      {protocol === "last-look-erc20" && isQuote && (
+      {isLastLook && isQuote && (
         <Button onClick={onGasFreeTradeButtonClick}>
           <StyledIcon name="star" iconSize={0.875} />
           {t("orders.gasFreeTrade")}
         </Button>
       )}
 
-      {protocol === "request-for-quote-erc20" && isQuote && (
+      {!isLastLook && isQuote && (
         <Quote>
           <NewQuoteText>{t("orders.newQuoteIn")}</NewQuoteText>
           {expiryTime && <StyledTimer expiryTime={expiryTime} />}

--- a/src/components/@widgets/SwapWidget/subcomponents/SwapWidgetHeader/SwapWidgetHeader.tsx
+++ b/src/components/@widgets/SwapWidget/subcomponents/SwapWidgetHeader/SwapWidgetHeader.tsx
@@ -46,7 +46,7 @@ const SwapWidgetHeader: FC<SwapWidgetHeaderProps> = ({
         </Button>
       )}
 
-      {!isLastLook && isQuote && (
+      {!isLastLook && isQuote && expiryTime && (
         <Quote>
           <NewQuoteText>{t("orders.newQuoteIn")}</NewQuoteText>
           {expiryTime && <StyledTimer expiryTime={expiryTime} />}

--- a/src/components/Toasts/ToastController.tsx
+++ b/src/components/Toasts/ToastController.tsx
@@ -10,6 +10,7 @@ import {
   SubmittedTransaction,
   SubmittedOrder,
   SubmittedWithdrawTransaction,
+  SubmittedOrderUnderConsideration,
 } from "../../entities/SubmittedTransaction/SubmittedTransaction";
 import findEthOrTokenByAddress from "../../helpers/findEthOrTokenByAddress";
 import { TransactionTypes } from "../../types/transactionTypes";
@@ -193,6 +194,13 @@ export const notifyOrderCreated = (order: FullOrderERC20) => {
       duration: 3000,
     }
   );
+};
+
+export const notifyOrderExpiry = (order: SubmittedOrderUnderConsideration) => {
+  notifyError({
+    heading: i18n.t("orders.swapRejected"),
+    cta: i18n.t("orders.swapRejectedCallToAction"),
+  });
 };
 
 export const notifyCopySuccess = () => {

--- a/src/components/Toasts/ToastController.tsx
+++ b/src/components/Toasts/ToastController.tsx
@@ -196,7 +196,7 @@ export const notifyOrderCreated = (order: FullOrderERC20) => {
   );
 };
 
-export const notifyOrderExpiry = (order: SubmittedOrderUnderConsideration) => {
+export const notifyOrderExpiry = () => {
   notifyError({
     heading: i18n.t("orders.swapRejected"),
     cta: i18n.t("orders.swapRejectedCallToAction"),

--- a/src/components/Toasts/ToastController.tsx
+++ b/src/components/Toasts/ToastController.tsx
@@ -8,7 +8,7 @@ import {
   SubmittedApprovalTransaction,
   SubmittedDepositTransaction,
   SubmittedTransaction,
-  SubmittedTransactionWithOrder,
+  SubmittedOrder,
   SubmittedWithdrawTransaction,
 } from "../../entities/SubmittedTransaction/SubmittedTransaction";
 import findEthOrTokenByAddress from "../../helpers/findEthOrTokenByAddress";
@@ -34,8 +34,7 @@ export const notifyTransaction = (
       type === TransactionTypes.withdraw) &&
     chainId
   ) {
-    const tx: SubmittedTransactionWithOrder =
-      transaction as SubmittedTransactionWithOrder;
+    const tx: SubmittedOrder = transaction as SubmittedOrder;
     /*  TODO: fix toaster for multiple tabs or apps
         now that we have a listener, you can have multiple
         tabs open that receives the same order event. Only one redux
@@ -140,7 +139,7 @@ export const notifyWithdrawal = (transaction: SubmittedWithdrawTransaction) => {
   );
 };
 
-export const notifyOrder = (transaction: SubmittedTransactionWithOrder) => {
+export const notifyOrder = (transaction: SubmittedOrder) => {
   toast(
     (t) => (
       <TransactionToast

--- a/src/components/Toasts/TransactionToast.tsx
+++ b/src/components/Toasts/TransactionToast.tsx
@@ -11,6 +11,7 @@ import {
   SubmittedRFQOrder,
   SubmittedTransaction,
 } from "../../entities/SubmittedTransaction/SubmittedTransaction";
+import { isLastLookOrderTransaction } from "../../entities/SubmittedTransaction/SubmittedTransactionHelpers";
 import { TransactionTypes } from "../../types/transactionTypes";
 import { InfoHeading } from "../Typography/Typography";
 import {
@@ -92,12 +93,11 @@ const TransactionToast = ({
               type === TransactionTypes.withdraw
             ) {
               if (transaction && senderToken && signerToken) {
-                const tx =
-                  transaction.protocol === "last-look-erc20"
-                    ? (transaction as SubmittedLastLookOrder)
-                    : (transaction as SubmittedRFQOrder);
+                const tx = isLastLookOrderTransaction(transaction)
+                  ? (transaction as SubmittedLastLookOrder)
+                  : (transaction as SubmittedRFQOrder);
                 let translationKey = "wallet.transaction";
-                if (tx.protocol === "last-look-erc20") {
+                if (tx.isLastLook) {
                   translationKey = "wallet.lastLookTransaction";
                 }
                 // @ts-ignore dynamic translation key

--- a/src/components/TransactionsTab/TransactionsTab.tsx
+++ b/src/components/TransactionsTab/TransactionsTab.tsx
@@ -15,6 +15,7 @@ import { formatUnits } from "ethers/lib/utils";
 import { AnimatePresence, useReducedMotion } from "framer-motion";
 
 import { SubmittedTransaction } from "../../entities/SubmittedTransaction/SubmittedTransaction";
+import { getSubmittedTransactionKey } from "../../entities/SubmittedTransaction/SubmittedTransactionHelpers";
 import { BalancesState } from "../../features/balances/balancesSlice";
 import useAddressOrEnsName from "../../hooks/useAddressOrEnsName";
 import { useKeyPress } from "../../hooks/useKeyPress";
@@ -225,7 +226,7 @@ const TransactionsTab = ({
               <AnimatePresence initial={false}>
                 {pendingTransactions.map((transaction) => (
                   <AnimatedWalletTransaction
-                    key={`${transaction.hash}-${transaction.nonce}-${transaction.expiry}-pending`}
+                    key={getSubmittedTransactionKey(transaction)}
                     transaction={transaction}
                     tokens={tokens}
                     chainId={chainId!}
@@ -243,7 +244,7 @@ const TransactionsTab = ({
               <AnimatePresence initial={false}>
                 {completedTransactions.map((transaction) => (
                   <AnimatedWalletTransaction
-                    key={`${transaction.hash}-${transaction.nonce}-${transaction.expiry}`}
+                    key={getSubmittedTransactionKey(transaction)}
                     transaction={transaction}
                     tokens={tokens}
                     chainId={chainId!}

--- a/src/components/TransactionsTab/TransactionsTab.tsx
+++ b/src/components/TransactionsTab/TransactionsTab.tsx
@@ -54,6 +54,7 @@ type TransactionsTabType = {
   address: string;
   chainId: number;
   open: boolean;
+  protocolFee: number;
   setTransactionsTabOpen: (x: boolean) => void;
   onClearTransactionsChange: (value: ClearOrderType) => void;
   /**
@@ -61,7 +62,6 @@ type TransactionsTabType = {
    */
   onDisconnectWalletClicked: () => void;
   transactions: SubmittedTransaction[];
-  tokens: TokenInfo[];
   balances: BalancesState;
   isUnsupportedNetwork?: boolean;
 };
@@ -70,11 +70,11 @@ const TransactionsTab = ({
   address = "",
   chainId,
   open,
+  protocolFee,
   setTransactionsTabOpen,
   onClearTransactionsChange,
   onDisconnectWalletClicked,
   transactions = [],
-  tokens = [],
   balances,
   isUnsupportedNetwork = false,
 }: TransactionsTabType) => {
@@ -227,8 +227,8 @@ const TransactionsTab = ({
                 {pendingTransactions.map((transaction) => (
                   <AnimatedWalletTransaction
                     key={getSubmittedTransactionKey(transaction)}
+                    protocolFee={protocolFee}
                     transaction={transaction}
-                    tokens={tokens}
                     chainId={chainId!}
                   />
                 ))}
@@ -245,8 +245,8 @@ const TransactionsTab = ({
                 {completedTransactions.map((transaction) => (
                   <AnimatedWalletTransaction
                     key={getSubmittedTransactionKey(transaction)}
+                    protocolFee={protocolFee}
                     transaction={transaction}
-                    tokens={tokens}
                     chainId={chainId!}
                   />
                 ))}

--- a/src/components/TransactionsTab/subcomponents/AnimatedWalletTransaction/AnimatedWalletTransaction.tsx
+++ b/src/components/TransactionsTab/subcomponents/AnimatedWalletTransaction/AnimatedWalletTransaction.tsx
@@ -11,23 +11,14 @@ import { walletTransactionHeight } from "../WalletTransaction/WalletTransaction.
 import { Container } from "./AnimatedWalletTransaction.styles";
 
 interface AnimatedWalletTransactionProps {
-  /**
-   * The parent object of SubmittedOrder and SubmittedApproval
-   */
+  protocolFee: number;
   transaction: SubmittedTransaction;
-  /**
-   * All token metadata
-   */
-  tokens: TokenInfo[];
-  /**
-   * chainId of current Ethereum net
-   */
   chainId: number;
 }
 
 const AnimatedWalletTransaction = ({
+  protocolFee,
   transaction,
-  tokens,
   chainId,
 }: AnimatedWalletTransactionProps) => {
   const theme = useTheme();
@@ -71,6 +62,7 @@ const AnimatedWalletTransaction = ({
       <WalletTransaction
         animate={{ borderColor: theme.colors.borderGrey }}
         initial={!transactionTooOld && { borderColor: theme.colors.white }}
+        protocolFee={protocolFee}
         transition={{
           delay: heightAnimationDuration,
           duration: borderAnimationDuration,

--- a/src/components/TransactionsTab/subcomponents/WalletTransaction/WalletTransaction.tsx
+++ b/src/components/TransactionsTab/subcomponents/WalletTransaction/WalletTransaction.tsx
@@ -11,6 +11,7 @@ import {
   isApprovalTransaction,
   isCancelTransaction,
   isDepositTransaction,
+  isLastLookOrderTransaction,
   isOrderTransaction,
   isWithdrawTransaction,
 } from "../../../../entities/SubmittedTransaction/SubmittedTransactionHelpers";
@@ -111,7 +112,7 @@ const WalletTransaction = ({
     // For last look transactions, the user has sent the signer amount plus
     // the fee:
     let signerAmountWithFee: string | null = null;
-    if (transaction.protocol === "last-look-erc20") {
+    if (isLastLookOrderTransaction(transaction)) {
       signerAmountWithFee = new BigNumber(transaction.order.signerAmount)
         .multipliedBy(1.0007)
         .integerValue(BigNumber.ROUND_FLOOR)
@@ -138,7 +139,7 @@ const WalletTransaction = ({
                 }
               >
                 {t(
-                  transaction.protocol === "last-look-erc20"
+                  isOrderTransaction(transaction) && transaction.isLastLook
                     ? "wallet.lastLookTransaction"
                     : "wallet.transaction",
                   {

--- a/src/components/TransactionsTab/subcomponents/WalletTransaction/WalletTransaction.tsx
+++ b/src/components/TransactionsTab/subcomponents/WalletTransaction/WalletTransaction.tsx
@@ -13,6 +13,7 @@ import {
   isDepositTransaction,
   isLastLookOrderTransaction,
   isSubmittedOrder,
+  isSubmittedOrderUnderConsideration,
   isWithdrawTransaction,
 } from "../../../../entities/SubmittedTransaction/SubmittedTransactionHelpers";
 import { TransactionStatusType } from "../../../../types/transactionTypes";
@@ -61,7 +62,9 @@ const WalletTransaction = ({
     return (
       <Container transition={transition} animate={animate} initial={initial}>
         <TextContainer>
-          <SpanTitle>{t("wallet.approve")}</SpanTitle>
+          <SpanTitle>
+            {t("wallet.approve", { symbol: transaction.token.symbol })}
+          </SpanTitle>
 
           <SpanSubtitle>
             {statusText} · {timeBetween}
@@ -103,6 +106,7 @@ const WalletTransaction = ({
 
   if (
     isSubmittedOrder(transaction) ||
+    isSubmittedOrderUnderConsideration(transaction) ||
     isWithdrawTransaction(transaction) ||
     isDepositTransaction(transaction)
   ) {
@@ -181,7 +185,7 @@ const WalletTransaction = ({
           )}
         </TextContainer>
 
-        {transaction.hash && (
+        {!isSubmittedOrderUnderConsideration(transaction) && (
           <StyledTransactionLink
             hideLabel
             chainId={chainId}

--- a/src/components/TransactionsTab/subcomponents/WalletTransaction/WalletTransaction.tsx
+++ b/src/components/TransactionsTab/subcomponents/WalletTransaction/WalletTransaction.tsx
@@ -30,17 +30,13 @@ import {
 } from "./WalletTransaction.styles";
 
 interface WalletTransactionProps extends HTMLMotionProps<"div"> {
-  /**
-   * The parent object of SubmittedOrder and SubmittedApproval
-   */
+  protocolFee: number;
   transaction: SubmittedTransaction;
-  /**
-   * chainId of current Ethereum net
-   */
   chainId: number;
 }
 
 const WalletTransaction = ({
+  protocolFee,
   transaction,
   chainId,
   animate,
@@ -120,7 +116,7 @@ const WalletTransaction = ({
     let signerAmountWithFee: string | null = null;
     if (isLastLookOrderTransaction(transaction)) {
       signerAmountWithFee = new BigNumber(transaction.order.signerAmount)
-        .multipliedBy(1.0007)
+        .multipliedBy(1 + protocolFee / 10000)
         .integerValue(BigNumber.ROUND_FLOOR)
         .toString();
     }

--- a/src/components/TransactionsTab/subcomponents/WalletTransaction/WalletTransaction.tsx
+++ b/src/components/TransactionsTab/subcomponents/WalletTransaction/WalletTransaction.tsx
@@ -12,7 +12,7 @@ import {
   isCancelTransaction,
   isDepositTransaction,
   isLastLookOrderTransaction,
-  isOrderTransaction,
+  isSubmittedOrder,
   isWithdrawTransaction,
 } from "../../../../entities/SubmittedTransaction/SubmittedTransactionHelpers";
 import { TransactionStatusType } from "../../../../types/transactionTypes";
@@ -102,7 +102,7 @@ const WalletTransaction = ({
   }
 
   if (
-    isOrderTransaction(transaction) ||
+    isSubmittedOrder(transaction) ||
     isWithdrawTransaction(transaction) ||
     isDepositTransaction(transaction)
   ) {
@@ -139,7 +139,7 @@ const WalletTransaction = ({
                 }
               >
                 {t(
-                  isOrderTransaction(transaction) && transaction.isLastLook
+                  isSubmittedOrder(transaction) && transaction.isLastLook
                     ? "wallet.lastLookTransaction"
                     : "wallet.transaction",
                   {

--- a/src/components/TransactionsTab/subcomponents/WalletTransaction/WalletTransaction.tsx
+++ b/src/components/TransactionsTab/subcomponents/WalletTransaction/WalletTransaction.tsx
@@ -107,7 +107,9 @@ const WalletTransaction = ({
     isDepositTransaction(transaction)
   ) {
     const { signerToken, senderToken } = transaction;
-    const hasExpiry = !!transaction.expiry;
+    const expiry = isSubmittedOrder(transaction)
+      ? transaction.order.expiry
+      : undefined;
 
     // For last look transactions, the user has sent the signer amount plus
     // the fee:
@@ -134,7 +136,7 @@ const WalletTransaction = ({
             <>
               <SpanTitle
                 hasProgress={
-                  hasExpiry &&
+                  !!expiry &&
                   transaction.status === TransactionStatusType.processing
                 }
               >
@@ -164,11 +166,11 @@ const WalletTransaction = ({
                   }
                 )}
               </SpanTitle>
-              {hasExpiry &&
+              {!!expiry &&
               transaction.status === TransactionStatusType.processing ? (
                 <ProgressBar
                   startTime={transaction.timestamp}
-                  endTime={parseInt(transaction.expiry!) * 1000}
+                  endTime={+expiry * 1000}
                 />
               ) : (
                 <SpanSubtitle>

--- a/src/constants/configParams.ts
+++ b/src/constants/configParams.ts
@@ -27,7 +27,7 @@ export const LAST_LOOK_ORDER_EXPIRY_SEC = 2 * 60;
 /**
  * Time to wait after a swap has expired
  */
-export const ASSUMED_EXPIRY_NOTIFICATION_BUFFER_MS = 20 * 1000;
+export const ASSUMED_EXPIRY_NOTIFICATION_BUFFER_SEC = 20;
 
 /**
  * Time to wait for quotes before presenting "no peers" message.

--- a/src/contexts/lastLook/LastLook.tsx
+++ b/src/contexts/lastLook/LastLook.tsx
@@ -13,14 +13,8 @@ import { useWeb3React } from "@web3-react/core";
 import BigNumber from "bignumber.js";
 
 import { useAppDispatch, useAppSelector } from "../../app/hooks";
-import { notifyError } from "../../components/Toasts/ToastController";
 import { LAST_LOOK_ORDER_EXPIRY_SEC } from "../../constants/configParams";
-import { SubmittedTransactionWithOrder } from "../../entities/SubmittedTransaction/SubmittedTransaction";
-// import { submitTransactionWithExpiry } from "../../features/transactions/transactionsSlice";
-import {
-  transformToSubmittedLastLookOrder,
-  transformToSubmittedRFQOrder,
-} from "../../entities/SubmittedTransaction/SubmittedTransactionTransformers";
+import { transformToSubmittedLastLookOrder } from "../../entities/SubmittedTransaction/SubmittedTransactionTransformers";
 import {
   selectAllTokenInfo,
   selectProtocolFee,
@@ -188,6 +182,8 @@ const LastLookProvider: FC = ({ children }) => {
         signerToken!,
         senderToken!
       );
+
+      console.log(transaction);
 
       dispatch(
         submitTransactionWithExpiry({

--- a/src/contexts/lastLook/LastLook.tsx
+++ b/src/contexts/lastLook/LastLook.tsx
@@ -14,7 +14,7 @@ import BigNumber from "bignumber.js";
 
 import { useAppDispatch, useAppSelector } from "../../app/hooks";
 import { LAST_LOOK_ORDER_EXPIRY_SEC } from "../../constants/configParams";
-import { transformToSubmittedLastLookOrder } from "../../entities/SubmittedTransaction/SubmittedTransactionTransformers";
+import { transformToSubmittedTransactionWithOrderUnderConsideration } from "../../entities/SubmittedTransaction/SubmittedTransactionTransformers";
 import {
   selectAllTokenInfo,
   selectProtocolFee,
@@ -176,14 +176,12 @@ const LastLookProvider: FC = ({ children }) => {
       const signerToken = tokens.find((t) => t.address === order.signerToken);
       const senderToken = tokens.find((t) => t.address === order.senderToken);
 
-      const transaction = transformToSubmittedLastLookOrder(
-        undefined,
-        order,
-        signerToken!,
-        senderToken!
-      );
-
-      console.log(transaction);
+      const transaction =
+        transformToSubmittedTransactionWithOrderUnderConsideration(
+          order,
+          signerToken!,
+          senderToken!
+        );
 
       dispatch(
         submitTransactionWithExpiry({

--- a/src/contexts/lastLook/LastLook.tsx
+++ b/src/contexts/lastLook/LastLook.tsx
@@ -21,7 +21,7 @@ import {
 } from "../../features/metadata/metadataSlice";
 import { updatePricing } from "../../features/pricing/pricingSlice";
 import { TradeTerms } from "../../features/tradeTerms/tradeTermsSlice";
-import { submitTransactionWithExpiry } from "../../features/transactions/transactionsSlice";
+import { submitTransaction } from "../../features/transactions/transactionsActions";
 
 type Pair = {
   baseToken: string;
@@ -135,7 +135,7 @@ const LastLookProvider: FC = ({ children }) => {
         .multipliedBy(10 ** terms.baseToken.decimals)
         // Note that we remove the signer fee from the amount that we send.
         // This was already done to determine quoteAmount.
-        .dividedBy(terms.side === "sell" ? 1.0007 : 1)
+        .dividedBy(terms.side === "sell" ? 1 + protocolFee / 10000 : 1)
         .integerValue(BigNumber.ROUND_CEIL)
         .toString();
       const quoteAmountAtomic = new BigNumber(terms.quoteAmount!)
@@ -183,12 +183,7 @@ const LastLookProvider: FC = ({ children }) => {
           senderToken!
         );
 
-      dispatch(
-        submitTransactionWithExpiry({
-          transaction,
-          signerWallet: unsignedOrder.signerWallet,
-        })
-      );
+      dispatch(submitTransaction(transaction));
 
       return {
         order,

--- a/src/entities/FullSwapERC20Event/FullSwapERC20EventHelpers.ts
+++ b/src/entities/FullSwapERC20Event/FullSwapERC20EventHelpers.ts
@@ -1,5 +1,9 @@
 import { TransactionEvent } from "../../types/transactionTypes";
-import { SubmittedOrder } from "../SubmittedTransaction/SubmittedTransaction";
+import {
+  SubmittedOrder,
+  SubmittedOrderUnderConsideration,
+} from "../SubmittedTransaction/SubmittedTransaction";
+import { isSubmittedOrder } from "../SubmittedTransaction/SubmittedTransactionHelpers";
 import { FullSwapERC20Event } from "./FullSwapERC20Event";
 
 export const isFullSwapERC20Event = (
@@ -8,10 +12,10 @@ export const isFullSwapERC20Event = (
   typeof event === "object" && "name" in event && event.name === "Swap";
 
 export const findMatchingOrderTransaction = (
-  transaction: SubmittedOrder,
+  transaction: SubmittedOrder | SubmittedOrderUnderConsideration,
   event: FullSwapERC20Event
 ): boolean => {
-  if (transaction.hash === event.hash) {
+  if (isSubmittedOrder(transaction) && transaction.hash === event.hash) {
     return true;
   }
 

--- a/src/entities/FullSwapERC20Event/FullSwapERC20EventHelpers.ts
+++ b/src/entities/FullSwapERC20Event/FullSwapERC20EventHelpers.ts
@@ -1,5 +1,5 @@
 import { TransactionEvent } from "../../types/transactionTypes";
-import { SubmittedTransactionWithOrder } from "../SubmittedTransaction/SubmittedTransaction";
+import { SubmittedOrder } from "../SubmittedTransaction/SubmittedTransaction";
 import { FullSwapERC20Event } from "./FullSwapERC20Event";
 
 export const isFullSwapERC20Event = (
@@ -8,7 +8,7 @@ export const isFullSwapERC20Event = (
   typeof event === "object" && "name" in event && event.name === "Swap";
 
 export const findMatchingOrderTransaction = (
-  transaction: SubmittedTransactionWithOrder,
+  transaction: SubmittedOrder,
   event: FullSwapERC20Event
 ): boolean => {
   if (transaction.hash === event.hash) {

--- a/src/entities/FullSwapERC20Event/FullSwapERC20EventHelpers.ts
+++ b/src/entities/FullSwapERC20Event/FullSwapERC20EventHelpers.ts
@@ -15,5 +15,5 @@ export const findMatchingOrderTransaction = (
     return true;
   }
 
-  return transaction.nonce === event.swap.nonce;
+  return transaction.order.nonce === event.swap.nonce;
 };

--- a/src/entities/SubmittedTransaction/SubmittedTransaction.ts
+++ b/src/entities/SubmittedTransaction/SubmittedTransaction.ts
@@ -21,7 +21,7 @@ export interface SubmittedTransaction {
   timestamp: number;
 }
 
-export interface SubmittedTransactionWithOrder extends SubmittedTransaction {
+export interface SubmittedOrder extends SubmittedTransaction {
   isLastLook?: boolean;
   type: TransactionTypes.order;
   order: OrderERC20;
@@ -29,16 +29,12 @@ export interface SubmittedTransactionWithOrder extends SubmittedTransaction {
   signerToken: TokenInfo;
 }
 
-export interface SubmittedTransactionWithOrderUnderConsideration
-  extends Omit<SubmittedTransactionWithOrder, "hash"> {
+export interface SubmittedOrderUnderConsideration
+  extends Omit<SubmittedOrder, "hash"> {
   isLastLook: true;
 }
 
-export interface SubmittedRFQOrder extends SubmittedTransactionWithOrder {
-  protocol: "request-for-quote-erc20";
-}
-
-export interface SubmittedLastLookOrder extends SubmittedTransactionWithOrder {
+export interface SubmittedLastLookOrder extends SubmittedOrder {
   isLastLook: true;
 }
 

--- a/src/entities/SubmittedTransaction/SubmittedTransaction.ts
+++ b/src/entities/SubmittedTransaction/SubmittedTransaction.ts
@@ -16,8 +16,6 @@ export interface SubmittedTransaction {
   type: TransactionTypes;
   hash?: string; // LL orders doesn't have hash
   status: TransactionStatusType;
-  nonce?: string;
-  expiry?: string;
   timestamp: number;
 }
 
@@ -48,6 +46,7 @@ export interface SubmittedApprovalTransaction extends SubmittedTransaction {
 
 export interface SubmittedCancellation extends SubmittedTransaction {
   hash: string;
+  nonce: string;
 }
 
 export interface SubmittedDepositTransaction extends SubmittedTransaction {

--- a/src/entities/SubmittedTransaction/SubmittedTransaction.ts
+++ b/src/entities/SubmittedTransaction/SubmittedTransaction.ts
@@ -14,12 +14,16 @@ export interface DepositOrWithdrawOrder {
 
 export interface SubmittedTransaction {
   type: TransactionTypes;
-  hash?: string; // LL orders doesn't have hash
+  hash?: string;
   status: TransactionStatusType;
   timestamp: number;
 }
 
-export interface SubmittedOrder extends SubmittedTransaction {
+export interface SubmittedTransactionWithHash extends SubmittedTransaction {
+  hash: string;
+}
+
+export interface SubmittedOrder extends SubmittedTransactionWithHash {
   isLastLook?: boolean;
   type: TransactionTypes.order;
   order: OrderERC20;
@@ -36,7 +40,8 @@ export interface SubmittedLastLookOrder extends SubmittedOrder {
   isLastLook: true;
 }
 
-export interface SubmittedApprovalTransaction extends SubmittedTransaction {
+export interface SubmittedApprovalTransaction
+  extends SubmittedTransactionWithHash {
   type: TransactionTypes.approval;
   hash: string;
   amount: string;
@@ -44,12 +49,13 @@ export interface SubmittedApprovalTransaction extends SubmittedTransaction {
   tokenAddress: string;
 }
 
-export interface SubmittedCancellation extends SubmittedTransaction {
+export interface SubmittedCancellation extends SubmittedTransactionWithHash {
   hash: string;
   nonce: string;
 }
 
-export interface SubmittedDepositTransaction extends SubmittedTransaction {
+export interface SubmittedDepositTransaction
+  extends SubmittedTransactionWithHash {
   type: TransactionTypes.deposit;
   hash: string;
   order: DepositOrWithdrawOrder;
@@ -57,7 +63,8 @@ export interface SubmittedDepositTransaction extends SubmittedTransaction {
   signerToken: TokenInfo;
 }
 
-export interface SubmittedWithdrawTransaction extends SubmittedTransaction {
+export interface SubmittedWithdrawTransaction
+  extends SubmittedTransactionWithHash {
   type: TransactionTypes.withdraw;
   hash: string;
   order: DepositOrWithdrawOrder;

--- a/src/entities/SubmittedTransaction/SubmittedTransaction.ts
+++ b/src/entities/SubmittedTransaction/SubmittedTransaction.ts
@@ -12,8 +12,6 @@ export interface DepositOrWithdrawOrder {
   senderAmount: string;
 }
 
-export type ProtocolType = "request-for-quote-erc20" | "last-look-erc20";
-
 export interface SubmittedTransaction {
   type: TransactionTypes;
   hash?: string; // LL orders doesn't have hash
@@ -21,14 +19,19 @@ export interface SubmittedTransaction {
   nonce?: string;
   expiry?: string;
   timestamp: number;
-  protocol?: ProtocolType;
 }
 
 export interface SubmittedTransactionWithOrder extends SubmittedTransaction {
+  isLastLook?: boolean;
   type: TransactionTypes.order;
   order: OrderERC20;
   senderToken: TokenInfo;
   signerToken: TokenInfo;
+}
+
+export interface SubmittedTransactionWithOrderUnderConsideration
+  extends Omit<SubmittedTransactionWithOrder, "hash"> {
+  isLastLook: true;
 }
 
 export interface SubmittedRFQOrder extends SubmittedTransactionWithOrder {
@@ -36,7 +39,7 @@ export interface SubmittedRFQOrder extends SubmittedTransactionWithOrder {
 }
 
 export interface SubmittedLastLookOrder extends SubmittedTransactionWithOrder {
-  protocol: "last-look-erc20";
+  isLastLook: true;
 }
 
 export interface SubmittedApprovalTransaction extends SubmittedTransaction {

--- a/src/entities/SubmittedTransaction/SubmittedTransactionHelpers.ts
+++ b/src/entities/SubmittedTransaction/SubmittedTransactionHelpers.ts
@@ -68,3 +68,18 @@ export const getSubmittedTransactionKey = (
 
   return transaction.hash;
 };
+
+export const doesTransactionsMatch = (
+  transaction: SubmittedTransaction,
+  match: SubmittedTransaction,
+  hash?: string
+): boolean => {
+  if (
+    isSubmittedOrderUnderConsideration(transaction) &&
+    isSubmittedOrderUnderConsideration(match)
+  ) {
+    return transaction.order.nonce === match.order.nonce;
+  }
+
+  return transaction.hash === match.hash || transaction.hash === hash;
+};

--- a/src/entities/SubmittedTransaction/SubmittedTransactionHelpers.ts
+++ b/src/entities/SubmittedTransaction/SubmittedTransactionHelpers.ts
@@ -4,10 +4,10 @@ import {
   SubmittedCancellation,
   SubmittedDepositTransaction,
   SubmittedLastLookOrder,
-  SubmittedRFQOrder,
   SubmittedTransaction,
-  SubmittedTransactionWithOrder,
+  SubmittedOrder,
   SubmittedWithdrawTransaction,
+  SubmittedOrderUnderConsideration,
 } from "./SubmittedTransaction";
 
 export const isApprovalTransaction = (
@@ -30,16 +30,26 @@ export const isWithdrawTransaction = (
 ): transaction is SubmittedWithdrawTransaction =>
   transaction.type === TransactionTypes.withdraw;
 
-export const isOrderTransaction = (
+export const isSubmittedOrder = (
   transaction: SubmittedTransaction
-): transaction is SubmittedTransactionWithOrder => {
-  return transaction.type === TransactionTypes.order;
+): transaction is SubmittedOrder => {
+  return transaction.type === TransactionTypes.order && !!transaction.hash;
+};
+
+export const isSubmittedOrderUnderConsideration = (
+  transaction: SubmittedTransaction
+): transaction is SubmittedOrderUnderConsideration => {
+  return transaction.type === TransactionTypes.order && !transaction.hash;
 };
 
 export const isLastLookOrderTransaction = (
   transaction: SubmittedTransaction
 ): transaction is SubmittedLastLookOrder => {
-  return isOrderTransaction(transaction) && !!transaction.isLastLook;
+  return (
+    isSubmittedOrder(transaction) &&
+    !!transaction.hash &&
+    !!transaction.isLastLook
+  );
 };
 
 export const sortSubmittedTransactionsByExpiry = (

--- a/src/entities/SubmittedTransaction/SubmittedTransactionHelpers.ts
+++ b/src/entities/SubmittedTransaction/SubmittedTransactionHelpers.ts
@@ -30,25 +30,16 @@ export const isWithdrawTransaction = (
 ): transaction is SubmittedWithdrawTransaction =>
   transaction.type === TransactionTypes.withdraw;
 
-export const isRfqOrderTransaction = (
-  transaction: SubmittedTransaction
-): transaction is SubmittedRFQOrder =>
-  transaction.type === TransactionTypes.order &&
-  transaction.protocol === "request-for-quote-erc20";
-
-export const isLastLookOrderTransaction = (
-  transaction: SubmittedTransaction
-): transaction is SubmittedLastLookOrder =>
-  transaction.type === TransactionTypes.order &&
-  transaction.protocol === "last-look-erc20";
-
 export const isOrderTransaction = (
   transaction: SubmittedTransaction
 ): transaction is SubmittedTransactionWithOrder => {
-  return (
-    isRfqOrderTransaction(transaction) ||
-    isLastLookOrderTransaction(transaction)
-  );
+  return transaction.type === TransactionTypes.order;
+};
+
+export const isLastLookOrderTransaction = (
+  transaction: SubmittedTransaction
+): transaction is SubmittedLastLookOrder => {
+  return isOrderTransaction(transaction) && !!transaction.isLastLook;
 };
 
 export const sortSubmittedTransactionsByExpiry = (

--- a/src/entities/SubmittedTransaction/SubmittedTransactionHelpers.ts
+++ b/src/entities/SubmittedTransaction/SubmittedTransactionHelpers.ts
@@ -58,3 +58,13 @@ export const sortSubmittedTransactionsByExpiry = (
 ) => {
   return b.timestamp - a.timestamp;
 };
+
+export const getSubmittedTransactionKey = (
+  transaction: SubmittedTransaction
+) => {
+  if (isSubmittedOrderUnderConsideration(transaction)) {
+    return `${transaction.order.nonce}-${transaction.timestamp}`;
+  }
+
+  return `${transaction.hash}-${transaction.timestamp}`;
+};

--- a/src/entities/SubmittedTransaction/SubmittedTransactionHelpers.ts
+++ b/src/entities/SubmittedTransaction/SubmittedTransactionHelpers.ts
@@ -63,8 +63,8 @@ export const getSubmittedTransactionKey = (
   transaction: SubmittedTransaction
 ) => {
   if (isSubmittedOrderUnderConsideration(transaction)) {
-    return `${transaction.order.nonce}-${transaction.timestamp}`;
+    return `${transaction.order.signerWallet}-${transaction.order.nonce}-${transaction.timestamp}`;
   }
 
-  return `${transaction.hash}-${transaction.timestamp}`;
+  return transaction.hash;
 };

--- a/src/entities/SubmittedTransaction/SubmittedTransactionTransformers.ts
+++ b/src/entities/SubmittedTransaction/SubmittedTransactionTransformers.ts
@@ -8,7 +8,8 @@ import {
   SubmittedApprovalTransaction,
   SubmittedDepositTransaction,
   SubmittedLastLookOrder,
-  SubmittedTransactionWithOrder,
+  SubmittedOrder,
+  SubmittedOrderUnderConsideration,
   SubmittedWithdrawTransaction,
 } from "./SubmittedTransaction";
 
@@ -75,45 +76,39 @@ export const transformToSubmittedWithdrawTransaction = (
   };
 };
 
-export const transformToSubmittedRFQOrder = (
+export const transformToSubmittedTransactionWithOrder = (
   hash: string,
   order: OrderERC20,
   signerToken: TokenInfo,
   senderToken: TokenInfo,
   status: TransactionStatusType = TransactionStatusType.processing,
   timestamp = Date.now()
-): SubmittedTransactionWithOrder => {
-  return {
-    type: TransactionTypes.order,
-    expiry: order.expiry,
-    hash,
-    nonce: order.nonce,
-    order,
-    senderToken,
-    signerToken,
-    status,
-    timestamp,
-  };
-};
+): SubmittedOrder => ({
+  type: TransactionTypes.order,
+  expiry: order.expiry,
+  hash,
+  nonce: order.nonce,
+  order,
+  senderToken,
+  signerToken,
+  status,
+  timestamp,
+});
 
-export const transformToSubmittedLastLookOrder = (
-  hash: string | undefined,
+export const transformToSubmittedTransactionWithOrderUnderConsideration = (
   order: OrderERC20,
   signerToken: TokenInfo,
   senderToken: TokenInfo,
   status: TransactionStatusType = TransactionStatusType.processing,
   timestamp = Date.now()
-): SubmittedLastLookOrder => {
-  return {
-    isLastLook: true,
-    type: TransactionTypes.order,
-    expiry: order.expiry,
-    hash,
-    nonce: order.nonce,
-    order,
-    senderToken,
-    signerToken,
-    status,
-    timestamp,
-  };
-};
+): SubmittedOrderUnderConsideration => ({
+  isLastLook: true,
+  type: TransactionTypes.order,
+  expiry: order.expiry,
+  nonce: order.nonce,
+  order,
+  senderToken,
+  signerToken,
+  status,
+  timestamp,
+});

--- a/src/entities/SubmittedTransaction/SubmittedTransactionTransformers.ts
+++ b/src/entities/SubmittedTransaction/SubmittedTransactionTransformers.ts
@@ -8,7 +8,7 @@ import {
   SubmittedApprovalTransaction,
   SubmittedDepositTransaction,
   SubmittedLastLookOrder,
-  SubmittedRFQOrder,
+  SubmittedTransactionWithOrder,
   SubmittedWithdrawTransaction,
 } from "./SubmittedTransaction";
 
@@ -82,14 +82,13 @@ export const transformToSubmittedRFQOrder = (
   senderToken: TokenInfo,
   status: TransactionStatusType = TransactionStatusType.processing,
   timestamp = Date.now()
-): SubmittedRFQOrder => {
+): SubmittedTransactionWithOrder => {
   return {
     type: TransactionTypes.order,
     expiry: order.expiry,
     hash,
     nonce: order.nonce,
     order,
-    protocol: "request-for-quote-erc20",
     senderToken,
     signerToken,
     status,
@@ -106,12 +105,12 @@ export const transformToSubmittedLastLookOrder = (
   timestamp = Date.now()
 ): SubmittedLastLookOrder => {
   return {
+    isLastLook: true,
     type: TransactionTypes.order,
     expiry: order.expiry,
     hash,
     nonce: order.nonce,
     order,
-    protocol: "last-look-erc20",
     senderToken,
     signerToken,
     status,

--- a/src/entities/SubmittedTransaction/SubmittedTransactionTransformers.ts
+++ b/src/entities/SubmittedTransaction/SubmittedTransactionTransformers.ts
@@ -85,9 +85,7 @@ export const transformToSubmittedTransactionWithOrder = (
   timestamp = Date.now()
 ): SubmittedOrder => ({
   type: TransactionTypes.order,
-  expiry: order.expiry,
   hash,
-  nonce: order.nonce,
   order,
   senderToken,
   signerToken,
@@ -104,8 +102,6 @@ export const transformToSubmittedTransactionWithOrderUnderConsideration = (
 ): SubmittedOrderUnderConsideration => ({
   isLastLook: true,
   type: TransactionTypes.order,
-  expiry: order.expiry,
-  nonce: order.nonce,
   order,
   senderToken,
   signerToken,

--- a/src/features/orders/ordersActions.ts
+++ b/src/features/orders/ordersActions.ts
@@ -52,7 +52,6 @@ import {
   revertTransaction,
   submitTransaction,
 } from "../transactions/transactionsActions";
-import { submitTransactionWithExpiry } from "../transactions/transactionsSlice";
 import {
   approveToken,
   depositETH,
@@ -409,11 +408,10 @@ export const approve =
 export const take =
   (
     order: OrderERC20 | FullOrderERC20,
-    senderToken: TokenInfo,
     signerToken: TokenInfo,
+    senderToken: TokenInfo,
     library: Web3Provider,
-    contractType: "Swap" | "Wrapper",
-    onExpired?: () => void
+    contractType: "Swap" | "Wrapper"
   ) =>
   async (dispatch: AppDispatch): Promise<void> => {
     dispatch(setStatus("signing"));
@@ -467,12 +465,6 @@ export const take =
       senderToken
     );
 
-    dispatch(
-      submitTransactionWithExpiry({
-        transaction,
-        signerWallet: order.signerWallet,
-        onExpired,
-      })
-    );
+    dispatch(submitTransaction(transaction));
     dispatch(setStatus("idle"));
   };

--- a/src/features/orders/ordersActions.ts
+++ b/src/features/orders/ordersActions.ts
@@ -27,13 +27,13 @@ import {
   SubmittedApprovalTransaction,
   SubmittedCancellation,
   SubmittedDepositTransaction,
-  SubmittedTransactionWithOrder,
+  SubmittedOrder,
   SubmittedWithdrawTransaction,
 } from "../../entities/SubmittedTransaction/SubmittedTransaction";
 import {
   transformToSubmittedApprovalTransaction,
   transformToSubmittedDepositTransaction,
-  transformToSubmittedRFQOrder,
+  transformToSubmittedTransactionWithOrder,
   transformToSubmittedWithdrawTransaction,
 } from "../../entities/SubmittedTransaction/SubmittedTransactionTransformers";
 import { AppErrorType, isAppError } from "../../errors/appError";
@@ -164,7 +164,7 @@ export const handleSubmittedWithdrawOrder = (
 };
 
 export const handleSubmittedRFQOrder = (
-  transaction: SubmittedTransactionWithOrder,
+  transaction: SubmittedOrder,
   status: TransactionStatusType
 ): void => {
   if (status === TransactionStatusType.failed) {
@@ -460,7 +460,7 @@ export const take =
         ? order
         : refactorOrder(order, library._network.chainId);
 
-    const transaction = transformToSubmittedRFQOrder(
+    const transaction = transformToSubmittedTransactionWithOrder(
       tx.hash,
       updatedOrder,
       signerToken,

--- a/src/features/orders/ordersActions.ts
+++ b/src/features/orders/ordersActions.ts
@@ -49,7 +49,6 @@ import {
 } from "../balances/balancesSlice";
 import {
   declineTransaction,
-  mineTransaction,
   revertTransaction,
   submitTransaction,
 } from "../transactions/transactionsActions";

--- a/src/features/orders/ordersSlice.ts
+++ b/src/features/orders/ordersSlice.ts
@@ -134,11 +134,6 @@ export const selectBestOption = createSelector(
         }
       | undefined;
 
-    // TODO: Delete this
-    // Temp disable bestRfqOrder
-    // @ts-ignore
-    // bestRfqOrder = null;
-
     if (!bestRfqOrder && !pricing) return undefined;
     let lastLookOrder;
     if (pricing) {

--- a/src/features/orders/ordersSlice.ts
+++ b/src/features/orders/ordersSlice.ts
@@ -137,7 +137,7 @@ export const selectBestOption = createSelector(
     // TODO: Delete this
     // Temp disable bestRfqOrder
     // @ts-ignore
-    bestRfqOrder = null;
+    // bestRfqOrder = null;
 
     if (!bestRfqOrder && !pricing) return undefined;
     let lastLookOrder;

--- a/src/features/orders/ordersSlice.ts
+++ b/src/features/orders/ordersSlice.ts
@@ -119,7 +119,7 @@ export const selectBestOption = createSelector(
     // TODO: Delete this
     // Temp disable bestRfqOrder
     // @ts-ignore
-    // bestRfqOrder = null;
+    bestRfqOrder = null;
 
     if (!bestRfqOrder && !pricing) return null;
     let lastLookOrder;

--- a/src/features/orders/ordersSlice.ts
+++ b/src/features/orders/ordersSlice.ts
@@ -97,36 +97,54 @@ export const selectSortedOrders = (state: RootState) =>
 
 export const selectFirstOrder = (state: RootState) => state.orders.orders[0];
 
+interface BestTradeOption {
+  quoteAmount: string;
+  isLastLook?: boolean;
+  pricing?: {
+    pricing: Levels;
+    locator: string;
+    quoteAmount: string;
+  };
+  order?: OrderERC20;
+}
+
 export const selectBestOption = createSelector(
   selectTradeTerms,
   selectBestOrder,
   selectBestPricing,
   selectGasPriceInQuoteTokens,
-  (terms, bestRfqOrder, bestPricing, gasPriceInQuoteTokens) => {
-    if (!terms) return null;
+  (
+    terms,
+    bestRfqOrder,
+    bestPricing,
+    gasPriceInQuoteTokens
+  ): BestTradeOption | undefined => {
+    if (!terms) return undefined;
 
     if (terms.side === "buy") {
       console.error(`Buy orders not implemented yet`);
-      return null;
+      return undefined;
     }
 
-    let pricing = bestPricing as unknown as {
-      pricing: Levels;
-      locator: string;
-      quoteAmount: string;
-    } | null;
+    let pricing = bestPricing as unknown as
+      | {
+          pricing: Levels;
+          locator: string;
+          quoteAmount: string;
+        }
+      | undefined;
 
     // TODO: Delete this
     // Temp disable bestRfqOrder
     // @ts-ignore
     bestRfqOrder = null;
 
-    if (!bestRfqOrder && !pricing) return null;
+    if (!bestRfqOrder && !pricing) return undefined;
     let lastLookOrder;
     if (pricing) {
       lastLookOrder = {
+        isLastLook: true,
         quoteAmount: pricing!.quoteAmount,
-        protocol: "last-look-erc20",
         pricing: pricing!,
       };
       if (!bestRfqOrder) return lastLookOrder;
@@ -140,7 +158,6 @@ export const selectBestOption = createSelector(
       );
       rfqOrder = {
         quoteAmount: bestRFQQuoteTokens.toString(),
-        protocol: "request-for-quote-erc20",
         order: bestRfqOrder,
       };
       if (!lastLookOrder) return rfqOrder;

--- a/src/features/transactions/hooks/useHistoricalTransactions.ts
+++ b/src/features/transactions/hooks/useHistoricalTransactions.ts
@@ -5,7 +5,7 @@ import { useWeb3React } from "@web3-react/core";
 import { useAppSelector } from "../../../app/hooks";
 import { SubmittedTransaction } from "../../../entities/SubmittedTransaction/SubmittedTransaction";
 import { sortSubmittedTransactionsByExpiry } from "../../../entities/SubmittedTransaction/SubmittedTransactionHelpers";
-import { transformToSubmittedRFQOrder } from "../../../entities/SubmittedTransaction/SubmittedTransactionTransformers";
+import { transformToSubmittedTransactionWithOrder } from "../../../entities/SubmittedTransaction/SubmittedTransactionTransformers";
 import { getUniqueArrayChildren } from "../../../helpers/array";
 import { getOrdersFromLogs } from "../../../helpers/getOrdersFromLogs";
 import { compareAddresses } from "../../../helpers/string";
@@ -75,7 +75,7 @@ const useHistoricalTransactions = (): [
 
           if (!signerToken || !senderToken) return;
 
-          return transformToSubmittedRFQOrder(
+          return transformToSubmittedTransactionWithOrder(
             order.hash,
             order.params,
             signerToken,

--- a/src/features/transactions/hooks/useHistoricalTransactions.ts
+++ b/src/features/transactions/hooks/useHistoricalTransactions.ts
@@ -55,11 +55,9 @@ const useHistoricalTransactions = (): [
     setTransactions(undefined);
 
     const getTransactionsFromLogs = async () => {
-      const rfqOrders = await getOrdersFromLogs(chainId, swapLogs.swapLogs);
-      // TODO: Add support for lastLook orders https://github.com/airswap/airswap-web/issues/891
-      // const lastLookOrders = await getOrdersFromLogs(swapLogs.swapLogs);
+      const orders = await getOrdersFromLogs(chainId, swapLogs.swapLogs);
 
-      const rfqSubmittedTransactions = rfqOrders
+      const submittedTransactions = orders
         .filter(
           (order) =>
             compareAddresses(order.params.signerWallet, account) ||
@@ -85,12 +83,12 @@ const useHistoricalTransactions = (): [
           );
         });
 
-      const transactions = rfqSubmittedTransactions.filter(
+      const transactions = submittedTransactions.filter(
         (order) => !!order
       ) as SubmittedTransaction[];
       const uniqueTransactions = getUniqueArrayChildren<SubmittedTransaction>(
         transactions,
-        "nonce"
+        "hash"
       );
 
       const sortedTransactions = uniqueTransactions.sort(

--- a/src/features/transactions/hooks/useLatestExpiredTransaction.ts
+++ b/src/features/transactions/hooks/useLatestExpiredTransaction.ts
@@ -4,14 +4,23 @@ import { useInterval } from "usehooks-ts";
 
 import { useAppSelector } from "../../../app/hooks";
 import {
+  ASSUMED_EXPIRY_NOTIFICATION_BUFFER_MS,
+  LAST_LOOK_ORDER_EXPIRY_SEC,
+} from "../../../constants/configParams";
+import {
+  SubmittedOrder,
   SubmittedOrderUnderConsideration,
   SubmittedTransaction,
 } from "../../../entities/SubmittedTransaction/SubmittedTransaction";
-import { isSubmittedOrderUnderConsideration } from "../../../entities/SubmittedTransaction/SubmittedTransactionHelpers";
+import {
+  isSubmittedOrder,
+  isSubmittedOrderUnderConsideration,
+} from "../../../entities/SubmittedTransaction/SubmittedTransactionHelpers";
 import { TransactionStatusType } from "../../../types/transactionTypes";
 import { selectTransactions } from "../transactionsSlice";
 
 const useLatestExpiredTransaction = ():
+  | SubmittedOrder
   | SubmittedOrderUnderConsideration
   | undefined => {
   const transactions: SubmittedTransaction[] =
@@ -22,16 +31,28 @@ const useLatestExpiredTransaction = ():
     setCurrentTime(Math.round(new Date().getTime() / 1000));
   }, 1000);
 
-  return useMemo(() => {
+  const lastExpiredOrderUnderConsideration = useMemo(() => {
     return transactions
       .filter(isSubmittedOrderUnderConsideration)
       .find((transaction) => {
         return (
           transaction.status === TransactionStatusType.processing &&
-          +transaction.order.expiry < currentTime
+          +transaction.order.expiry + LAST_LOOK_ORDER_EXPIRY_SEC < currentTime
         );
       });
   }, [transactions, currentTime]);
+
+  const lastExpiredOrderWithOrder = useMemo(() => {
+    return transactions.filter(isSubmittedOrder).find((transaction) => {
+      return (
+        transaction.status === TransactionStatusType.processing &&
+        +transaction.order.expiry + ASSUMED_EXPIRY_NOTIFICATION_BUFFER_MS <
+          currentTime
+      );
+    });
+  }, [transactions, currentTime]);
+
+  return lastExpiredOrderUnderConsideration || lastExpiredOrderWithOrder;
 };
 
 export default useLatestExpiredTransaction;

--- a/src/features/transactions/hooks/useLatestExpiredTransaction.ts
+++ b/src/features/transactions/hooks/useLatestExpiredTransaction.ts
@@ -1,0 +1,37 @@
+import { useMemo, useState } from "react";
+
+import { useInterval } from "usehooks-ts";
+
+import { useAppSelector } from "../../../app/hooks";
+import {
+  SubmittedOrderUnderConsideration,
+  SubmittedTransaction,
+} from "../../../entities/SubmittedTransaction/SubmittedTransaction";
+import { isSubmittedOrderUnderConsideration } from "../../../entities/SubmittedTransaction/SubmittedTransactionHelpers";
+import { TransactionStatusType } from "../../../types/transactionTypes";
+import { selectTransactions } from "../transactionsSlice";
+
+const useLatestExpiredTransaction = ():
+  | SubmittedOrderUnderConsideration
+  | undefined => {
+  const transactions: SubmittedTransaction[] =
+    useAppSelector(selectTransactions);
+  const [currentTime, setCurrentTime] = useState<number>(0);
+
+  useInterval(() => {
+    setCurrentTime(Math.round(new Date().getTime() / 1000));
+  }, 1000);
+
+  return useMemo(() => {
+    return transactions
+      .filter(isSubmittedOrderUnderConsideration)
+      .find((transaction) => {
+        return (
+          transaction.status === TransactionStatusType.processing &&
+          +transaction.order.expiry < currentTime
+        );
+      });
+  }, [transactions, currentTime]);
+};
+
+export default useLatestExpiredTransaction;

--- a/src/features/transactions/hooks/useLatestExpiredTransaction.ts
+++ b/src/features/transactions/hooks/useLatestExpiredTransaction.ts
@@ -4,7 +4,7 @@ import { useInterval } from "usehooks-ts";
 
 import { useAppSelector } from "../../../app/hooks";
 import {
-  ASSUMED_EXPIRY_NOTIFICATION_BUFFER_MS,
+  ASSUMED_EXPIRY_NOTIFICATION_BUFFER_SEC,
   LAST_LOOK_ORDER_EXPIRY_SEC,
 } from "../../../constants/configParams";
 import {
@@ -46,7 +46,7 @@ const useLatestExpiredTransaction = ():
     return transactions.filter(isSubmittedOrder).find((transaction) => {
       return (
         transaction.status === TransactionStatusType.processing &&
-        +transaction.order.expiry + ASSUMED_EXPIRY_NOTIFICATION_BUFFER_MS <
+        +transaction.order.expiry + ASSUMED_EXPIRY_NOTIFICATION_BUFFER_SEC <
           currentTime
       );
     });

--- a/src/features/transactions/transactionsActions.ts
+++ b/src/features/transactions/transactionsActions.ts
@@ -1,12 +1,12 @@
 import { createAction } from "@reduxjs/toolkit";
 
 import {
-  SubmittedApprovalTransaction,
+  SubmittedOrderUnderConsideration,
   SubmittedTransaction,
 } from "../../entities/SubmittedTransaction/SubmittedTransaction";
 
 export const submitTransaction = createAction<
-  SubmittedTransaction | SubmittedApprovalTransaction
+  SubmittedTransaction | SubmittedOrderUnderConsideration
 >("transaction/submitTransaction");
 
 export const declineTransaction = createAction<{

--- a/src/features/transactions/transactionsActions.ts
+++ b/src/features/transactions/transactionsActions.ts
@@ -18,13 +18,6 @@ export const declineTransaction = createAction<{
   protocol?: ProtocolType;
 }>("transactions/declineTransaction");
 
-export const mineTransaction = createAction<{
-  protocol?: ProtocolType;
-  signerWallet?: string;
-  hash?: string;
-  nonce?: string;
-}>("transaction/mineTransaction");
-
 export const revertTransaction = createAction<{
   hash?: string;
   signerWallet?: string;

--- a/src/features/transactions/transactionsActions.ts
+++ b/src/features/transactions/transactionsActions.ts
@@ -1,7 +1,6 @@
 import { createAction } from "@reduxjs/toolkit";
 
 import {
-  ProtocolType,
   SubmittedApprovalTransaction,
   SubmittedTransaction,
 } from "../../entities/SubmittedTransaction/SubmittedTransaction";
@@ -15,7 +14,6 @@ export const declineTransaction = createAction<{
   signerWallet?: string;
   nonce?: string;
   reason?: string;
-  protocol?: ProtocolType;
 }>("transactions/declineTransaction");
 
 export const revertTransaction = createAction<{

--- a/src/features/transactions/transactionsActions.ts
+++ b/src/features/transactions/transactionsActions.ts
@@ -23,11 +23,6 @@ export const revertTransaction = createAction<{
   reason?: string;
 }>("transactions/revertTransaction");
 
-export const expireTransaction = createAction<{
-  signerWallet: string;
-  nonce: string;
-}>("transactions/expireTransaction");
-
 export const updateTransactions = createAction<SubmittedTransaction[]>(
   "transactions/updateTransactions"
 );

--- a/src/features/transactions/transactionsHelpers.ts
+++ b/src/features/transactions/transactionsHelpers.ts
@@ -15,6 +15,7 @@ import {
 } from "../../entities/FullSwapERC20Event/FullSwapERC20EventHelpers";
 import {
   SubmittedDepositTransaction,
+  SubmittedOrderUnderConsideration,
   SubmittedTransaction,
   SubmittedWithdrawTransaction,
 } from "../../entities/SubmittedTransaction/SubmittedTransaction";
@@ -23,6 +24,7 @@ import {
   isCancelTransaction,
   isDepositTransaction,
   isSubmittedOrder,
+  isSubmittedOrderUnderConsideration,
   isWithdrawTransaction,
 } from "../../entities/SubmittedTransaction/SubmittedTransactionHelpers";
 import {
@@ -52,6 +54,27 @@ export const updateTransaction =
         transaction.hash === updatedTransaction.hash ||
         transaction.hash === previousHash
     );
+
+    if (transactionIndex === -1) {
+      return;
+    }
+
+    const updatedTransactions = [...transactions];
+    updatedTransactions.splice(transactionIndex, 1, updatedTransaction);
+
+    dispatch(setTransactions(updatedTransactions));
+  };
+
+export const updateExpiredTransaction =
+  (updatedTransaction: SubmittedOrderUnderConsideration) =>
+  async (dispatch: AppDispatch, getState: () => RootState): Promise<void> => {
+    const transactions = getState().transactions.transactions;
+    const transactionIndex = transactions
+      .filter(isSubmittedOrderUnderConsideration)
+      .findIndex(
+        (transaction) =>
+          transaction.order.nonce === updatedTransaction.order.nonce
+      );
 
     if (transactionIndex === -1) {
       return;

--- a/src/features/transactions/transactionsHelpers.ts
+++ b/src/features/transactions/transactionsHelpers.ts
@@ -22,7 +22,7 @@ import {
   isApprovalTransaction,
   isCancelTransaction,
   isDepositTransaction,
-  isOrderTransaction,
+  isSubmittedOrder,
   isWithdrawTransaction,
 } from "../../entities/SubmittedTransaction/SubmittedTransactionHelpers";
 import {
@@ -94,7 +94,7 @@ const getMatchingTransaction = (
 
   if (isFullSwapERC20Event(event)) {
     return transactions
-      .filter(isOrderTransaction)
+      .filter(isSubmittedOrder)
       .find((transaction) => findMatchingOrderTransaction(transaction, event));
   }
 
@@ -153,7 +153,7 @@ export const handleTransactionResolved =
       handleSubmittedWithdrawOrder(transaction, transaction.status, dispatch);
     }
 
-    if (isOrderTransaction(transaction)) {
+    if (isSubmittedOrder(transaction)) {
       handleSubmittedRFQOrder(transaction, transaction.status);
     }
 

--- a/src/features/transactions/transactionsHelpers.ts
+++ b/src/features/transactions/transactionsHelpers.ts
@@ -1,7 +1,6 @@
 import { TransactionReceipt } from "@ethersproject/providers";
 
 import { AppDispatch, RootState } from "../../app/store";
-import { ApproveEvent } from "../../entities/ApproveEvent/ApproveEvent";
 import {
   findMatchingApprovalTransaction,
   isApproveEvent,
@@ -10,7 +9,6 @@ import {
   findMatchingCancelTransaction,
   isCancelEvent,
 } from "../../entities/CancelEvent/CancelEventHelpers";
-import { FullSwapERC20Event } from "../../entities/FullSwapERC20Event/FullSwapERC20Event";
 import {
   findMatchingOrderTransaction,
   isFullSwapERC20Event,
@@ -24,12 +22,9 @@ import {
   isApprovalTransaction,
   isCancelTransaction,
   isDepositTransaction,
-  isLastLookOrderTransaction,
   isOrderTransaction,
-  isRfqOrderTransaction,
   isWithdrawTransaction,
 } from "../../entities/SubmittedTransaction/SubmittedTransactionHelpers";
-import { WETHEvent } from "../../entities/WETHEvent/WETHEvent";
 import {
   findMatchingDepositOrWithdrawTransaction,
   isWETHEvent,
@@ -158,10 +153,7 @@ export const handleTransactionResolved =
       handleSubmittedWithdrawOrder(transaction, transaction.status, dispatch);
     }
 
-    if (
-      isRfqOrderTransaction(transaction) ||
-      isLastLookOrderTransaction(transaction)
-    ) {
+    if (isOrderTransaction(transaction)) {
       handleSubmittedRFQOrder(transaction, transaction.status);
     }
 

--- a/src/features/transactions/transactionsHooks.ts
+++ b/src/features/transactions/transactionsHooks.ts
@@ -14,7 +14,6 @@ import useLatestSucceededTransaction from "./hooks/useLatestSucceededTransaction
 import useLatestTransactionEvent from "./hooks/useLatestTransactionEvent";
 import useTransactionsFilterFromLocalStorage from "./hooks/useTransactionsFilterFromLocalStorage";
 import {
-  updateExpiredTransaction,
   updateTransaction,
   updateTransactionWithReceipt,
 } from "./transactionsHelpers";
@@ -47,7 +46,7 @@ export const useTransactions = (): void => {
     if (!account || !chainId || !library) {
       return;
     }
-    console.log(transactions);
+
     setLocalStorageTransactions(account, chainId, transactions);
   }, [transactions]);
 
@@ -79,8 +78,6 @@ export const useTransactions = (): void => {
 
     processingTransactions.forEach(getTransactionReceiptAndUpdateTransaction);
 
-    console.log(localStorageTransactions);
-
     dispatch(setTransactions(localStorageTransactions));
   }, [account, chainId]);
 
@@ -101,7 +98,6 @@ export const useTransactions = (): void => {
       // Remove duplicates, in favour of store transactions.
       const uniqueTransactions = getUniqueArrayChildren<SubmittedTransaction>(
         updatedTransactions,
-        // TODO: LastLook orders could not have a hash, so we need to add an id prop
         "hash"
       );
       const sortedTransactions = uniqueTransactions.sort(
@@ -119,16 +115,16 @@ export const useTransactions = (): void => {
     }
   }, [latestTransactionEvent]);
 
-  // If a LastLook transaction was not taken in time after it was sent for consideration then it should be expired.
+  // If a transaction was not taken in time then it should be expired.
   useEffect(() => {
     if (latestExpiredTransaction) {
       dispatch(
-        updateExpiredTransaction({
+        updateTransaction({
           ...latestExpiredTransaction,
           status: TransactionStatusType.expired,
         })
       );
-      notifyOrderExpiry(latestExpiredTransaction);
+      notifyOrderExpiry();
     }
   }, [latestExpiredTransaction]);
 

--- a/src/features/transactions/transactionsSlice.ts
+++ b/src/features/transactions/transactionsSlice.ts
@@ -27,7 +27,6 @@ import {
 import {
   declineTransaction,
   expireTransaction,
-  mineTransaction,
   revertTransaction,
   submitTransaction,
   updateTransactions,
@@ -109,7 +108,7 @@ export const submitTransactionWithExpiry = createAsyncThunk<
     state: RootState;
   }
 >(
-  "orders/approve",
+  "orders/submitTransactionWithExpiry",
   async ({ transaction, signerWallet, onExpired }, { getState, dispatch }) => {
     dispatch(submitTransaction(transaction));
     if (!transaction.expiry) {
@@ -189,17 +188,6 @@ export const transactionsSlice = createSlice({
         signerWallet,
         nonce,
         status: TransactionStatusType.expired,
-      });
-    });
-    builder.addCase(mineTransaction, (state, action) => {
-      clearExpiry(action.payload.signerWallet, action.payload.nonce);
-      updateTransaction({
-        state,
-        hash: action.payload.hash,
-        nonce: action.payload.nonce,
-        signerWallet: action.payload.signerWallet,
-        status: TransactionStatusType.succeeded,
-        protocol: action.payload.protocol,
       });
     });
     builder.addCase(updateTransactions, (state, action): TransactionsState => {

--- a/src/features/transactions/transactionsSlice.ts
+++ b/src/features/transactions/transactionsSlice.ts
@@ -13,6 +13,7 @@ import {
   SubmittedDepositTransaction,
   SubmittedLastLookOrder,
   SubmittedTransaction,
+  SubmittedOrder,
 } from "../../entities/SubmittedTransaction/SubmittedTransaction";
 import { ClearOrderType } from "../../types/clearOrderType";
 import {
@@ -57,7 +58,7 @@ function updateTransaction(params: {
     const swap = state.transactions.find(
       (s) =>
         s.nonce === nonce &&
-        (s as SubmittedLastLookOrder).order.signerWallet.toLowerCase() ===
+        (s as SubmittedOrder).order.signerWallet.toLowerCase() ===
           signerWallet!.toLowerCase()
     );
     if (swap) {

--- a/src/features/transactions/transactionsSlice.ts
+++ b/src/features/transactions/transactionsSlice.ts
@@ -11,7 +11,6 @@ import {
   SubmittedApprovalTransaction,
   SubmittedCancellation,
   SubmittedDepositTransaction,
-  SubmittedLastLookOrder,
   SubmittedTransaction,
   SubmittedOrder,
   SubmittedOrderUnderConsideration,

--- a/src/features/transactions/transactionsSlice.ts
+++ b/src/features/transactions/transactionsSlice.ts
@@ -8,7 +8,6 @@ import {
 import { AppDispatch, RootState } from "../../app/store";
 import { ASSUMED_EXPIRY_NOTIFICATION_BUFFER_MS } from "../../constants/configParams";
 import {
-  ProtocolType,
   SubmittedApprovalTransaction,
   SubmittedCancellation,
   SubmittedDepositTransaction,
@@ -52,7 +51,6 @@ function updateTransaction(params: {
   hash?: string;
   signerWallet?: string;
   status: TransactionStatusType;
-  protocol?: ProtocolType;
 }): void {
   const { state, nonce, hash, signerWallet, status } = params;
   if (!!signerWallet && !!nonce) {
@@ -167,7 +165,6 @@ export const transactionsSlice = createSlice({
         nonce: action.payload.nonce,
         signerWallet: action.payload.signerWallet,
         status: TransactionStatusType.declined,
-        protocol: action.payload.protocol,
       });
     });
     builder.addCase(revertTransaction, (state, action) => {

--- a/src/features/transactions/transactionsUtils.ts
+++ b/src/features/transactions/transactionsUtils.ts
@@ -2,14 +2,14 @@ import { BaseProvider, TransactionReceipt } from "@ethersproject/providers";
 
 import {
   SubmittedTransaction,
-  SubmittedTransactionWithOrder,
+  SubmittedOrder,
 } from "../../entities/SubmittedTransaction/SubmittedTransaction";
 import { parseJsonArray } from "../../helpers/array";
 import { TransactionStatusType } from "../../types/transactionTypes";
 
 export const isTransactionWithOrder = (
   transaction: SubmittedTransaction
-): transaction is SubmittedTransactionWithOrder => {
+): transaction is SubmittedOrder => {
   return "order" in transaction;
 };
 

--- a/src/features/transactions/transactionsUtils.ts
+++ b/src/features/transactions/transactionsUtils.ts
@@ -1,26 +1,11 @@
 import { BaseProvider, TransactionReceipt } from "@ethersproject/providers";
 
-import { AppDispatch } from "../../app/store";
 import {
   SubmittedTransaction,
   SubmittedTransactionWithOrder,
 } from "../../entities/SubmittedTransaction/SubmittedTransaction";
-import {
-  isApprovalTransaction,
-  isDepositTransaction,
-  isLastLookOrderTransaction,
-  isRfqOrderTransaction,
-  isWithdrawTransaction,
-} from "../../entities/SubmittedTransaction/SubmittedTransactionHelpers";
 import { parseJsonArray } from "../../helpers/array";
 import { TransactionStatusType } from "../../types/transactionTypes";
-import {
-  handleApproveTransaction,
-  handleSubmittedDepositOrder,
-  handleSubmittedRFQOrder,
-  handleSubmittedWithdrawOrder,
-} from "../orders/ordersActions";
-import { updateTransaction } from "./transactionsHelpers";
 
 export const isTransactionWithOrder = (
   transaction: SubmittedTransaction
@@ -95,10 +80,6 @@ export const getTransactionReceipt = async (
   library: BaseProvider
 ): Promise<TransactionReceipt | undefined> => {
   let hash = transaction.hash;
-
-  if (isLastLookOrderTransaction(transaction)) {
-    hash = transaction.order.nonce;
-  }
 
   if (!hash) {
     console.error("Transaction hash is not found");

--- a/src/features/wallet/Wallet.tsx
+++ b/src/features/wallet/Wallet.tsx
@@ -43,6 +43,7 @@ import {
   selectActiveTokens,
   selectAllTokenInfo,
   selectMetaDataReducer,
+  selectProtocolFee,
 } from "../metadata/metadataSlice";
 import { fetchSupportedTokens } from "../registry/registryActions";
 import {
@@ -81,8 +82,8 @@ export const Wallet: FC<WalletPropsType> = ({
   const { providerName } = useAppSelector(selectWallet);
   const transactions = useAppSelector(selectFilteredTransactions);
   const pendingTransactions = useAppSelector(selectPendingTransactions);
+  const protocolFee = useAppSelector(selectProtocolFee);
   const { isFetchingAllTokens } = useAppSelector(selectMetaDataReducer);
-  const allTokens = useAppSelector(selectAllTokenInfo);
 
   // Interface context
   const { transactionsTabIsOpen, setShowWalletList, setTransactionsTabIsOpen } =
@@ -285,6 +286,7 @@ export const Wallet: FC<WalletPropsType> = ({
         address={account!}
         chainId={chainId!}
         open={transactionsTabIsOpen}
+        protocolFee={protocolFee}
         setTransactionsTabOpen={setTransactionsTabIsOpen}
         onClearTransactionsChange={handleClearTransactionsChange}
         onDisconnectWalletClicked={() => {
@@ -296,7 +298,6 @@ export const Wallet: FC<WalletPropsType> = ({
           setTransactionsTabIsOpen(false);
         }}
         transactions={transactions}
-        tokens={allTokens}
         balances={balances!}
         isUnsupportedNetwork={error && error instanceof UnsupportedChainIdError}
       />

--- a/src/hooks/useOrderTransaction.ts
+++ b/src/hooks/useOrderTransaction.ts
@@ -2,6 +2,7 @@ import { useMemo } from "react";
 
 import { useAppSelector } from "../app/hooks";
 import { SubmittedTransaction } from "../entities/SubmittedTransaction/SubmittedTransaction";
+import { isSubmittedOrder } from "../entities/SubmittedTransaction/SubmittedTransactionHelpers";
 import { selectOrderTransactions } from "../features/transactions/transactionsSlice";
 
 const useOrderTransaction = (
@@ -10,7 +11,10 @@ const useOrderTransaction = (
   const transactions = useAppSelector(selectOrderTransactions);
 
   return useMemo(() => {
-    return transactions.find((transaction) => transaction.nonce === nonce);
+    return transactions.find(
+      (transaction) =>
+        isSubmittedOrder(transaction) && transaction.order.nonce === nonce
+    );
   }, [transactions, nonce]);
 };
 

--- a/src/hooks/useOrderTransactionLink.ts
+++ b/src/hooks/useOrderTransactionLink.ts
@@ -6,6 +6,7 @@ import { useWeb3React } from "@web3-react/core";
 
 import { useAppSelector } from "../app/hooks";
 import { SubmittedTransaction } from "../entities/SubmittedTransaction/SubmittedTransaction";
+import { isSubmittedOrder } from "../entities/SubmittedTransaction/SubmittedTransactionHelpers";
 import { selectTransactions } from "../features/transactions/transactionsSlice";
 import { TransactionStatusType } from "../types/transactionTypes";
 
@@ -17,7 +18,8 @@ const useOrderTransactionLink = (nonce: string): string | undefined => {
   return useMemo(() => {
     const succeededTransaction = transactions.find(
       (transaction) =>
-        transaction.nonce === nonce &&
+        isSubmittedOrder(transaction) &&
+        transaction.order.nonce === nonce &&
         transaction.status === TransactionStatusType.succeeded
     );
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -11537,6 +11537,13 @@ url-parse@^1.5.3:
     querystringify "^2.1.1"
     requires-port "^1.0.0"
 
+usehooks-ts@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/usehooks-ts/-/usehooks-ts-3.1.0.tgz#156119f36efc85f1b1952616c02580f140950eca"
+  integrity sha512-bBIa7yUyPhE1BCc0GmR96VU/15l/9gP1Ch5mYdLcFBaFGQsdmXkvjV0TtOqW1yUd6VjIwDunm+flSciCQXujiw==
+  dependencies:
+    lodash.debounce "^4.0.8"
+
 utf-8-validate@^5.0.2:
   version "5.0.10"
   resolved "https://registry.yarnpkg.com/utf-8-validate/-/utf-8-validate-5.0.10.tgz#d7d10ea39318171ca982718b6b96a8d2442571a2"


### PR DESCRIPTION
Fixes #891  

Expiry of LastLook transactions are now handled in the transactionHooks file.

Removed all logic for keeping track of expired transactions from store. This is considered bad practice, you should only store data in your store. Adding timeouts will create side effects and will make cleanup more complicated.

Added a SubmittedOrderUnderConsideration interface for LastLook orders that are submitted but not have a transaction hash yet and are sent for consideration to LastLook.

Removed the `last-look` and `request-for-quote` types. All orders are now the same, except when it has a `isLastLook=true`. Then the hash can be optional.