### PR TITLE
893: Add FullSwapERC20 to order transactions

### DIFF
--- a/src/components/@widgets/SwapWidget/SwapWidget.tsx
+++ b/src/components/@widgets/SwapWidget/SwapWidget.tsx
@@ -13,7 +13,6 @@ import { Registry, Server, Wrapper } from "@airswap/libraries";
 import { OrderERC20, Pricing, ProtocolIds, ADDRESS_ZERO } from "@airswap/utils";
 import { Web3Provider } from "@ethersproject/providers";
 import { useToggle } from "@react-hookz/web";
-import { unwrapResult } from "@reduxjs/toolkit";
 import { UnsupportedChainIdError, useWeb3React } from "@web3-react/core";
 
 import { useAppDispatch, useAppSelector } from "../../../app/hooks";

--- a/src/components/@widgets/SwapWidget/hooks/useBestTradeOptionTransaction.ts
+++ b/src/components/@widgets/SwapWidget/hooks/useBestTradeOptionTransaction.ts
@@ -27,10 +27,9 @@ const useBestTradeOptionTransaction = (
 
       const senderAmount = toAtomicString(quoteAmount, tokenInfo.decimals);
 
-      return (
-        transaction.order.nonce === nonce ||
-        transaction.order.senderAmount === senderAmount
-      );
+      return transaction.order.nonce
+        ? transaction.order.nonce === nonce
+        : transaction.order.senderAmount === senderAmount;
     });
   }, [transactions, nonce, quoteAmount]);
 };

--- a/src/components/TransactionsTab/TransactionsTab.tsx
+++ b/src/components/TransactionsTab/TransactionsTab.tsx
@@ -51,7 +51,7 @@ import AnimatedWalletTransaction from "./subcomponents/AnimatedWalletTransaction
 import ClearTransactionsSelector from "./subcomponents/ClearTransactionsSelector/ClearTransactionsSelector";
 
 type TransactionsTabType = {
-  address: string;
+  account: string;
   chainId: number;
   open: boolean;
   protocolFee: number;
@@ -67,7 +67,7 @@ type TransactionsTabType = {
 };
 
 const TransactionsTab = ({
-  address = "",
+  account = "",
   chainId,
   open,
   protocolFee,
@@ -92,7 +92,7 @@ const TransactionsTab = ({
   const transactionsScrollRef = useRef<HTMLDivElement>(null);
   const buttonRef = useRef<HTMLDivElement>(null);
 
-  const addressOrName = useAddressOrEnsName(address);
+  const addressOrName = useAddressOrEnsName(account);
   const walletInfoText = useMemo(() => {
     return isUnsupportedNetwork
       ? t("wallet.unsupported")
@@ -101,8 +101,8 @@ const TransactionsTab = ({
       : t("wallet.notConnected");
   }, [addressOrName, isUnsupportedNetwork, t]);
   const walletUrl = useMemo(
-    () => getAccountUrl(chainId, address),
-    [chainId, address]
+    () => getAccountUrl(chainId, account),
+    [chainId, account]
   );
   useKeyPress(() => setTransactionsTabOpen(false), ["Escape"]);
 
@@ -205,7 +205,7 @@ const TransactionsTab = ({
             {showMobileMenu && (
               <StyledWalletMobileMenu
                 walletUrl={walletUrl}
-                address={address}
+                address={account}
                 onDisconnectButtonClick={onDisconnectWalletClicked}
               />
             )}
@@ -230,6 +230,7 @@ const TransactionsTab = ({
                     protocolFee={protocolFee}
                     transaction={transaction}
                     chainId={chainId!}
+                    account={account}
                   />
                 ))}
               </AnimatePresence>
@@ -248,6 +249,7 @@ const TransactionsTab = ({
                     protocolFee={protocolFee}
                     transaction={transaction}
                     chainId={chainId!}
+                    account={account}
                   />
                 ))}
               </AnimatePresence>

--- a/src/components/TransactionsTab/helpers/getWalletTransactionOrderText.ts
+++ b/src/components/TransactionsTab/helpers/getWalletTransactionOrderText.ts
@@ -1,0 +1,97 @@
+import { TokenInfo } from "@airswap/utils";
+import { formatUnits } from "@ethersproject/units";
+
+import { BigNumber } from "bignumber.js";
+
+import { SubmittedTransaction } from "../../../entities/SubmittedTransaction/SubmittedTransaction";
+import {
+  isDepositTransaction,
+  isLastLookOrderTransaction,
+  isSubmittedOrder,
+  isWithdrawTransaction,
+} from "../../../entities/SubmittedTransaction/SubmittedTransactionHelpers";
+import { compareAddresses } from "../../../helpers/string";
+import i18n from "../../../i18n/i18n";
+
+const isSenderWalletAccount = (
+  transaction: SubmittedTransaction,
+  account: string
+) => {
+  if (isSubmittedOrder(transaction) && transaction.swap) {
+    return compareAddresses(transaction.swap.senderWallet, account);
+  }
+
+  return false;
+};
+
+const getWalletTransactionOrderText = (
+  transaction: SubmittedTransaction,
+  signerToken: TokenInfo,
+  senderToken: TokenInfo,
+  account: string,
+  protocolFee: number
+): string => {
+  if (
+    !(
+      isSubmittedOrder(transaction) ||
+      isWithdrawTransaction(transaction) ||
+      isDepositTransaction(transaction)
+    )
+  ) {
+    return "";
+  }
+
+  const orderOrSwap =
+    isSubmittedOrder(transaction) && transaction.swap
+      ? transaction.swap
+      : transaction.order;
+
+  let signerAmountWithFee: string | undefined = undefined;
+
+  if (isLastLookOrderTransaction(transaction)) {
+    signerAmountWithFee = new BigNumber(orderOrSwap.signerAmount)
+      .multipliedBy(1 + protocolFee / 10000)
+      .integerValue(BigNumber.ROUND_FLOOR)
+      .toString();
+  }
+
+  const translation =
+    isSubmittedOrder(transaction) && transaction.isLastLook
+      ? "wallet.lastLookTransaction"
+      : "wallet.transaction";
+
+  const signerAmount = parseFloat(
+    Number(
+      formatUnits(
+        signerAmountWithFee || orderOrSwap.signerAmount,
+        signerToken.decimals
+      )
+    ).toFixed(5)
+  );
+
+  const senderAmount = parseFloat(
+    Number(formatUnits(orderOrSwap.senderAmount, senderToken.decimals)).toFixed(
+      5
+    )
+  );
+
+  const accountIsSender = isSenderWalletAccount(transaction, account);
+
+  if (accountIsSender) {
+    return i18n.t(translation, {
+      signerAmount,
+      signerToken: signerToken.symbol,
+      senderAmount,
+      senderToken: senderToken.symbol,
+    });
+  }
+
+  return i18n.t(translation, {
+    signerAmount: senderAmount,
+    signerToken: senderToken.symbol,
+    senderAmount: signerAmount,
+    senderToken: signerToken.symbol,
+  });
+};
+
+export default getWalletTransactionOrderText;

--- a/src/components/TransactionsTab/helpers/getWalletTransactionOrderText.ts
+++ b/src/components/TransactionsTab/helpers/getWalletTransactionOrderText.ts
@@ -3,8 +3,15 @@ import { formatUnits } from "@ethersproject/units";
 
 import { BigNumber } from "bignumber.js";
 
-import { SubmittedTransaction } from "../../../entities/SubmittedTransaction/SubmittedTransaction";
 import {
+  SubmittedDepositTransaction,
+  SubmittedOrder,
+  SubmittedTransaction,
+  SubmittedWithdrawTransaction,
+} from "../../../entities/SubmittedTransaction/SubmittedTransaction";
+import {
+  getDepositOrWithdrawalTransactionLabel,
+  getOrderTransactionLabel,
   isDepositTransaction,
   isLastLookOrderTransaction,
   isSubmittedOrder,
@@ -13,85 +20,31 @@ import {
 import { compareAddresses } from "../../../helpers/string";
 import i18n from "../../../i18n/i18n";
 
-const isSenderWalletAccount = (
-  transaction: SubmittedTransaction,
-  account: string
-) => {
-  if (isSubmittedOrder(transaction) && transaction.swap) {
-    return compareAddresses(transaction.swap.senderWallet, account);
-  }
-
-  return false;
-};
-
 const getWalletTransactionOrderText = (
-  transaction: SubmittedTransaction,
+  transaction:
+    | SubmittedOrder
+    | SubmittedWithdrawTransaction
+    | SubmittedDepositTransaction,
   signerToken: TokenInfo,
   senderToken: TokenInfo,
   account: string,
   protocolFee: number
 ): string => {
-  if (
-    !(
-      isSubmittedOrder(transaction) ||
-      isWithdrawTransaction(transaction) ||
-      isDepositTransaction(transaction)
-    )
-  ) {
-    return "";
+  if (isWithdrawTransaction(transaction) || isDepositTransaction(transaction)) {
+    return getDepositOrWithdrawalTransactionLabel(
+      transaction,
+      signerToken,
+      senderToken
+    );
   }
 
-  const orderOrSwap =
-    isSubmittedOrder(transaction) && transaction.swap
-      ? transaction.swap
-      : transaction.order;
-
-  let signerAmountWithFee: string | undefined = undefined;
-
-  if (isLastLookOrderTransaction(transaction)) {
-    signerAmountWithFee = new BigNumber(orderOrSwap.signerAmount)
-      .multipliedBy(1 + protocolFee / 10000)
-      .integerValue(BigNumber.ROUND_FLOOR)
-      .toString();
-  }
-
-  const translation =
-    isSubmittedOrder(transaction) && transaction.isLastLook
-      ? "wallet.lastLookTransaction"
-      : "wallet.transaction";
-
-  const signerAmount = parseFloat(
-    Number(
-      formatUnits(
-        signerAmountWithFee || orderOrSwap.signerAmount,
-        signerToken.decimals
-      )
-    ).toFixed(5)
+  return getOrderTransactionLabel(
+    transaction,
+    signerToken,
+    senderToken,
+    account,
+    protocolFee
   );
-
-  const senderAmount = parseFloat(
-    Number(formatUnits(orderOrSwap.senderAmount, senderToken.decimals)).toFixed(
-      5
-    )
-  );
-
-  const accountIsSender = isSenderWalletAccount(transaction, account);
-
-  if (accountIsSender) {
-    return i18n.t(translation, {
-      signerAmount,
-      signerToken: signerToken.symbol,
-      senderAmount,
-      senderToken: senderToken.symbol,
-    });
-  }
-
-  return i18n.t(translation, {
-    signerAmount: senderAmount,
-    signerToken: senderToken.symbol,
-    senderAmount: signerAmount,
-    senderToken: signerToken.symbol,
-  });
 };
 
 export default getWalletTransactionOrderText;

--- a/src/components/TransactionsTab/subcomponents/AnimatedWalletTransaction/AnimatedWalletTransaction.tsx
+++ b/src/components/TransactionsTab/subcomponents/AnimatedWalletTransaction/AnimatedWalletTransaction.tsx
@@ -1,7 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
 
-import { TokenInfo } from "@airswap/utils";
-
 import { useReducedMotion } from "framer-motion";
 import { useTheme } from "styled-components";
 
@@ -14,12 +12,14 @@ interface AnimatedWalletTransactionProps {
   protocolFee: number;
   transaction: SubmittedTransaction;
   chainId: number;
+  account: string;
 }
 
 const AnimatedWalletTransaction = ({
   protocolFee,
   transaction,
   chainId,
+  account,
 }: AnimatedWalletTransactionProps) => {
   const theme = useTheme();
   const shouldReduceMotion = useReducedMotion();
@@ -69,6 +69,7 @@ const AnimatedWalletTransaction = ({
         }}
         transaction={transaction}
         chainId={chainId}
+        account={account}
       />
     </Container>
   );

--- a/src/entities/SubmittedTransaction/SubmittedTransaction.ts
+++ b/src/entities/SubmittedTransaction/SubmittedTransaction.ts
@@ -1,4 +1,4 @@
-import { OrderERC20, TokenInfo } from "@airswap/utils";
+import { FullSwapERC20, OrderERC20, TokenInfo } from "@airswap/utils";
 
 import {
   TransactionStatusType,
@@ -27,6 +27,7 @@ export interface SubmittedOrder extends SubmittedTransactionWithHash {
   isLastLook?: boolean;
   type: TransactionTypes.order;
   order: OrderERC20;
+  swap?: FullSwapERC20;
   senderToken: TokenInfo;
   signerToken: TokenInfo;
 }

--- a/src/entities/SubmittedTransaction/SubmittedTransactionHelpers.ts
+++ b/src/entities/SubmittedTransaction/SubmittedTransactionHelpers.ts
@@ -33,7 +33,7 @@ export const isWithdrawTransaction = (
 export const isSubmittedOrder = (
   transaction: SubmittedTransaction
 ): transaction is SubmittedOrder => {
-  return transaction.type === TransactionTypes.order && !!transaction.hash;
+  return transaction.type === TransactionTypes.order;
 };
 
 export const isSubmittedOrderUnderConsideration = (
@@ -69,7 +69,7 @@ export const getSubmittedTransactionKey = (
   return transaction.hash;
 };
 
-export const doesTransactionsMatch = (
+export const doTransactionsMatch = (
   transaction: SubmittedTransaction,
   match: SubmittedTransaction,
   hash?: string

--- a/src/entities/SubmittedTransaction/SubmittedTransactionHelpers.ts
+++ b/src/entities/SubmittedTransaction/SubmittedTransactionHelpers.ts
@@ -1,3 +1,10 @@
+import { TokenInfo } from "@airswap/utils";
+import { formatUnits } from "@ethersproject/units";
+
+import { BigNumber } from "bignumber.js";
+
+import { compareAddresses } from "../../helpers/string";
+import i18n from "../../i18n/i18n";
 import { TransactionTypes } from "../../types/transactionTypes";
 import {
   SubmittedApprovalTransaction,
@@ -82,4 +89,84 @@ export const doTransactionsMatch = (
   }
 
   return transaction.hash === match.hash || transaction.hash === hash;
+};
+
+export const getDepositOrWithdrawalTransactionLabel = (
+  transaction: SubmittedDepositTransaction | SubmittedWithdrawTransaction,
+  signerToken: TokenInfo,
+  senderToken: TokenInfo
+): string => {
+  return i18n.t("wallet.transaction", {
+    signerAmount: transaction.order.signerAmount,
+    signerToken: signerToken.symbol,
+    senderAmount: transaction.order.signerAmount,
+    senderToken: senderToken.symbol,
+  });
+};
+
+const isSenderWalletAccount = (
+  transaction: SubmittedTransaction,
+  account: string
+) => {
+  if (isSubmittedOrder(transaction) && transaction.swap) {
+    return compareAddresses(transaction.swap.senderWallet, account);
+  }
+
+  return false;
+};
+
+export const getOrderTransactionLabel = (
+  transaction: SubmittedOrder,
+  signerToken: TokenInfo,
+  senderToken: TokenInfo,
+  account: string,
+  protocolFee: number
+) => {
+  const { order, swap } = transaction;
+
+  const signerAmountWithFee =
+    !swap && transaction.isLastLook
+      ? new BigNumber(transaction.order.signerAmount)
+          .multipliedBy(1 + protocolFee / 10000)
+          .integerValue(BigNumber.ROUND_FLOOR)
+          .toString()
+      : undefined;
+
+  const translation =
+    isSubmittedOrder(transaction) && transaction.isLastLook
+      ? "wallet.lastLookTransaction"
+      : "wallet.transaction";
+
+  const signerAmount = parseFloat(
+    Number(
+      formatUnits(
+        signerAmountWithFee || (swap || order).signerAmount,
+        signerToken.decimals
+      )
+    ).toFixed(5)
+  );
+
+  const senderAmount = parseFloat(
+    Number(
+      formatUnits((swap || order).senderAmount, senderToken.decimals)
+    ).toFixed(5)
+  );
+
+  const accountIsSender = isSenderWalletAccount(transaction, account);
+
+  if (accountIsSender) {
+    return i18n.t(translation, {
+      signerAmount,
+      signerToken: signerToken.symbol,
+      senderAmount,
+      senderToken: senderToken.symbol,
+    });
+  }
+
+  return i18n.t(translation, {
+    signerAmount: senderAmount,
+    signerToken: senderToken.symbol,
+    senderAmount: signerAmount,
+    senderToken: signerToken.symbol,
+  });
 };

--- a/src/entities/SubmittedTransaction/SubmittedTransactionHelpers.ts
+++ b/src/entities/SubmittedTransaction/SubmittedTransactionHelpers.ts
@@ -96,10 +96,22 @@ export const getDepositOrWithdrawalTransactionLabel = (
   signerToken: TokenInfo,
   senderToken: TokenInfo
 ): string => {
+  const signerAmount = parseFloat(
+    Number(
+      formatUnits(transaction.order.signerAmount, signerToken.decimals)
+    ).toFixed(5)
+  );
+
+  const senderAmount = parseFloat(
+    Number(
+      formatUnits(transaction.order.senderAmount, senderToken.decimals)
+    ).toFixed(5)
+  );
+
   return i18n.t("wallet.transaction", {
-    signerAmount: transaction.order.signerAmount,
+    signerAmount,
     signerToken: signerToken.symbol,
-    senderAmount: transaction.order.signerAmount,
+    senderAmount,
     senderToken: senderToken.symbol,
   });
 };

--- a/src/entities/SubmittedTransaction/SubmittedTransactionTransformers.ts
+++ b/src/entities/SubmittedTransaction/SubmittedTransactionTransformers.ts
@@ -1,4 +1,4 @@
-import { OrderERC20, TokenInfo } from "@airswap/utils";
+import { FullSwapERC20, OrderERC20, TokenInfo } from "@airswap/utils";
 
 import {
   TransactionStatusType,
@@ -7,7 +7,6 @@ import {
 import {
   SubmittedApprovalTransaction,
   SubmittedDepositTransaction,
-  SubmittedLastLookOrder,
   SubmittedOrder,
   SubmittedOrderUnderConsideration,
   SubmittedWithdrawTransaction,
@@ -81,6 +80,7 @@ export const transformToSubmittedTransactionWithOrder = (
   order: OrderERC20,
   signerToken: TokenInfo,
   senderToken: TokenInfo,
+  swap?: FullSwapERC20,
   status: TransactionStatusType = TransactionStatusType.processing,
   timestamp = Date.now()
 ): SubmittedOrder => ({
@@ -90,6 +90,7 @@ export const transformToSubmittedTransactionWithOrder = (
   senderToken,
   signerToken,
   status,
+  swap,
   timestamp,
 });
 

--- a/src/features/orders/ordersActions.ts
+++ b/src/features/orders/ordersActions.ts
@@ -162,7 +162,7 @@ export const handleSubmittedWithdrawOrder = (
   notifyWithdrawal(transaction);
 };
 
-export const handleSubmittedRFQOrder = (
+export const handleSubmittedOrder = (
   transaction: SubmittedOrder,
   status: TransactionStatusType
 ): void => {

--- a/src/features/transactions/hooks/useHistoricalTransactions.ts
+++ b/src/features/transactions/hooks/useHistoricalTransactions.ts
@@ -55,31 +55,32 @@ const useHistoricalTransactions = (): [
     setTransactions(undefined);
 
     const getTransactionsFromLogs = async () => {
-      const orders = await getOrdersFromLogs(chainId, swapLogs.swapLogs);
+      const logs = await getOrdersFromLogs(chainId, swapLogs.swapLogs);
 
-      const submittedTransactions = orders
+      const submittedTransactions = logs
         .filter(
           (order) =>
-            compareAddresses(order.params.signerWallet, account) ||
-            compareAddresses(order.senderWallet, account)
+            compareAddresses(order.order.signerWallet, account) ||
+            compareAddresses(order.swap.senderWallet, account)
         )
-        .map((order) => {
+        .map((log) => {
           const signerToken = tokens.find(
-            (token) => token.address === order.params.signerToken
+            (token) => token.address === log.order.signerToken
           );
           const senderToken = tokens.find(
-            (token) => token.address === order.params.senderToken
+            (token) => token.address === log.order.senderToken
           );
 
           if (!signerToken || !senderToken) return;
 
           return transformToSubmittedTransactionWithOrder(
-            order.hash,
-            order.params,
+            log.hash,
+            log.order,
             signerToken,
             senderToken,
+            log.swap,
             TransactionStatusType.succeeded,
-            order.timestamp
+            log.timestamp
           );
         });
 

--- a/src/features/wallet/Wallet.tsx
+++ b/src/features/wallet/Wallet.tsx
@@ -283,7 +283,7 @@ export const Wallet: FC<WalletPropsType> = ({
         />
       </TopBar>
       <TransactionsTab
-        address={account!}
+        account={account!}
         chainId={chainId!}
         open={transactionsTabIsOpen}
         protocolFee={protocolFee}


### PR DESCRIPTION
Fixes #893 

- Completed orders now have a swap property with the FullSwapERC20.
- Added helpers for wallet transaction labels