### PR TITLE
Fix: Added overwrite limit order warning

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -172,6 +172,7 @@
     "noIndexerOrdersFound": "No orders found for this token pair",
     "noIndexersFound": "No indexer nodes found",
     "orderSuccessfullyCreated": "Order successfully created.",
+    "overwriteLimitOrderWarning": "You already have a limit order for this token pair. If you submit a new order, the existing order will be overwritten.",
     "pendingWallet": "Waiting for wallet",
     "pendingConfirmation": "Confirm to sign transaction",
     "pendingSignature": "Confirm to sign signature",

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -172,7 +172,7 @@
     "noIndexerOrdersFound": "No orders found for this token pair",
     "noIndexersFound": "No indexer nodes found",
     "orderSuccessfullyCreated": "Order successfully created.",
-    "overwriteLimitOrderWarning": "You already have a limit order for this token pair. If you submit a new order, the existing order will be overwritten.",
+    "overwriteLimitOrderWarning": "Pair already has a limit order; it will be replaced.",
     "pendingWallet": "Waiting for wallet",
     "pendingConfirmation": "Confirm to sign transaction",
     "pendingSignature": "Confirm to sign signature",

--- a/src/components/@widgets/MakeWidget/MakeWidget.tsx
+++ b/src/components/@widgets/MakeWidget/MakeWidget.tsx
@@ -245,6 +245,7 @@ const MakeWidget: FC<MakeWidgetProps> = ({ isLimitOrder = false }) => {
     orderAmount: signerShouldPayProtocolFee ? makerAmountPlusFee : makerAmount,
     spenderAddressType,
     tokenInfo: makerTokenInfo,
+    takerTokenInfo,
   });
   const shouldShowOverwriteLimitOrderNotice =
     useShouldShowOverwriteLimitOrderNotice({
@@ -620,7 +621,7 @@ const MakeWidget: FC<MakeWidgetProps> = ({ isLimitOrder = false }) => {
             onSignButtonClick={approveToken}
           />
 
-          {shouldShowApprovalNotice && !shouldShowOverwriteLimitOrderNotice && (
+          {shouldShowApprovalNotice && (
             <ApprovalNotice
               activeState="approvalReview"
               orderAmount={
@@ -629,6 +630,7 @@ const MakeWidget: FC<MakeWidgetProps> = ({ isLimitOrder = false }) => {
               chainId={chainId}
               spenderAddressType={spenderAddressType}
               tokenInfo={makerTokenInfo}
+              takerTokenInfo={takerTokenInfo}
             />
           )}
         </>
@@ -656,7 +658,7 @@ const MakeWidget: FC<MakeWidgetProps> = ({ isLimitOrder = false }) => {
           />
           {shouldShowOverwriteLimitOrderNotice && <OverwriteLimitOrderNotice />}
 
-          {shouldShowApprovalNotice && !shouldShowOverwriteLimitOrderNotice && (
+          {shouldShowApprovalNotice && (
             <ApprovalNotice
               activeState="orderReview"
               orderAmount={

--- a/src/components/@widgets/MakeWidget/MakeWidget.tsx
+++ b/src/components/@widgets/MakeWidget/MakeWidget.tsx
@@ -84,6 +84,8 @@ import DepositSubmittedScreen from "../../DepositSubmittedScreen/DepositSubmitte
 import { SelectOption } from "../../Dropdown/Dropdown";
 import OrderTypesModal from "../../InformationModals/subcomponents/OrderTypesModal/OrderTypesModal";
 import ModalOverlay from "../../ModalOverlay/ModalOverlay";
+import { OverwriteLimitOrderNotice } from "../../OverwriteLimitOrderNotice/OverwriteLimitOrderNotice";
+import { useShouldShowOverwriteLimitOrderNotice } from "../../OverwriteLimitOrderNotice/hooks/useShouldShowOverwriteLimitOrderNotice";
 import ProtocolFeeOverlay from "../../ProtocolFeeOverlay/ProtocolFeeOverlay";
 import SetRuleSubmittedScreen from "../../SetRuleSubmittedScreen/SetRuleSubmittedScreen";
 import { notifyOrderCreated } from "../../Toasts/ToastController";
@@ -244,6 +246,12 @@ const MakeWidget: FC<MakeWidgetProps> = ({ isLimitOrder = false }) => {
     spenderAddressType,
     tokenInfo: makerTokenInfo,
   });
+  const shouldShowOverwriteLimitOrderNotice =
+    useShouldShowOverwriteLimitOrderNotice({
+      chainId,
+      makerTokenInfo,
+      takerTokenInfo,
+    });
 
   // Modal states
   const { setShowWalletList, transactionsTabIsOpen } =
@@ -612,7 +620,7 @@ const MakeWidget: FC<MakeWidgetProps> = ({ isLimitOrder = false }) => {
             onSignButtonClick={approveToken}
           />
 
-          {shouldShowApprovalNotice && (
+          {shouldShowApprovalNotice && !shouldShowOverwriteLimitOrderNotice && (
             <ApprovalNotice
               activeState="approvalReview"
               orderAmount={
@@ -646,8 +654,9 @@ const MakeWidget: FC<MakeWidgetProps> = ({ isLimitOrder = false }) => {
             onEditButtonClick={handleEditButtonClick}
             onSignButtonClick={createOrder}
           />
+          {shouldShowOverwriteLimitOrderNotice && <OverwriteLimitOrderNotice />}
 
-          {shouldShowApprovalNotice && (
+          {shouldShowApprovalNotice && !shouldShowOverwriteLimitOrderNotice && (
             <ApprovalNotice
               activeState="orderReview"
               orderAmount={

--- a/src/components/ApprovalNotice/ApprovalNotice.tsx
+++ b/src/components/ApprovalNotice/ApprovalNotice.tsx
@@ -28,6 +28,7 @@ type ApprovalNoticeProps = {
   chainId?: number;
   spenderAddressType: AllowancesType;
   tokenInfo: AppTokenInfo | null;
+  takerTokenInfo?: AppTokenInfo | null;
   className?: string;
 };
 
@@ -38,6 +39,7 @@ export const ApprovalNotice: FC<ApprovalNoticeProps> = ({
   chainId,
   spenderAddressType,
   tokenInfo,
+  takerTokenInfo,
   className,
 }) => {
   const { t } = useTranslation();
@@ -50,6 +52,7 @@ export const ApprovalNotice: FC<ApprovalNoticeProps> = ({
   const [totalTokenAllowance] = useTotalTokenAllowanceFromOrders(
     spenderAddressType,
     tokenInfo,
+    takerTokenInfo,
     chainId
   );
 

--- a/src/components/ApprovalNotice/helpers.ts
+++ b/src/components/ApprovalNotice/helpers.ts
@@ -101,7 +101,8 @@ const filterTokenOrder = async (
   allowanceType: AllowancesType,
   provider: ethers.providers.BaseProvider,
   chainId: number,
-  tokenId?: string
+  tokenId?: string,
+  takerTokenAddress?: string
 ): Promise<boolean> => {
   const now = Math.floor(new Date().getTime() / 1000);
 
@@ -128,6 +129,17 @@ const filterTokenOrder = async (
     return false;
   }
 
+  console.log(takerTokenAddress, isDelegateRule(order) && order.signerToken);
+
+  // If delegate rule, exclude orders that are for the same pair because they will be overwritten
+  if (
+    takerTokenAddress &&
+    isDelegateRule(order) &&
+    compareAddresses(order.signerToken, takerTokenAddress)
+  ) {
+    return false;
+  }
+
   if (expiry < now) {
     return false;
   }
@@ -148,7 +160,8 @@ export const getTotalTokenAllowanceFromOrders = async (
   provider: ethers.providers.BaseProvider,
   chainId: number,
   protocolFee: number,
-  tokenId?: string
+  tokenId?: string,
+  takerTokenAddress?: string
 ): Promise<string> => {
   if (!tokenAddress) {
     return "0";
@@ -163,7 +176,8 @@ export const getTotalTokenAllowanceFromOrders = async (
         allowanceType,
         provider,
         chainId,
-        tokenId
+        tokenId,
+        takerTokenAddress
       ),
     }))
   );

--- a/src/components/ApprovalNotice/helpers.ts
+++ b/src/components/ApprovalNotice/helpers.ts
@@ -129,8 +129,6 @@ const filterTokenOrder = async (
     return false;
   }
 
-  console.log(takerTokenAddress, isDelegateRule(order) && order.signerToken);
-
   // If delegate rule, exclude orders that are for the same pair because they will be overwritten
   if (
     takerTokenAddress &&

--- a/src/components/ApprovalNotice/hooks/useShouldShowApprovalNotice.ts
+++ b/src/components/ApprovalNotice/hooks/useShouldShowApprovalNotice.ts
@@ -8,6 +8,7 @@ type UseShouldShowApprovalNoticeProps = {
   chainId?: number;
   spenderAddressType: AllowancesType;
   tokenInfo: AppTokenInfo | null;
+  takerTokenInfo?: AppTokenInfo | null;
   className?: string;
 };
 
@@ -16,9 +17,15 @@ export const useShouldShowApprovalNotice = ({
   chainId,
   spenderAddressType,
   tokenInfo,
+  takerTokenInfo,
 }: UseShouldShowApprovalNoticeProps): boolean => {
   const [totalTokenAllowance, isLoadingTotalTokenAllowance] =
-    useTotalTokenAllowanceFromOrders(spenderAddressType, tokenInfo, chainId);
+    useTotalTokenAllowanceFromOrders(
+      spenderAddressType,
+      tokenInfo,
+      takerTokenInfo,
+      chainId
+    );
 
   const userHasNoOrders = totalTokenAllowance === "0";
   const totalNeededAllowance = getTotalNeededAllowance(

--- a/src/components/ApprovalNotice/hooks/useTotalTokenAllowanceFromOrders.ts
+++ b/src/components/ApprovalNotice/hooks/useTotalTokenAllowanceFromOrders.ts
@@ -19,6 +19,7 @@ import { getTotalTokenAllowanceFromOrders } from "../helpers";
 export const useTotalTokenAllowanceFromOrders = (
   spenderAddressType: AllowancesType,
   tokenInfo: AppTokenInfo | null,
+  takerTokenInfo?: AppTokenInfo | null,
   chainId?: number
 ): [string | undefined, boolean] => {
   const { provider } = useWeb3React();
@@ -44,6 +45,10 @@ export const useTotalTokenAllowanceFromOrders = (
         tokenInfo.address === ADDRESS_ZERO
           ? wrappedNativeToken.address
           : tokenInfo.address;
+      const justifiedTakerTokenAddress =
+        takerTokenInfo?.address === ADDRESS_ZERO
+          ? wrappedNativeToken.address
+          : takerTokenInfo?.address;
       const tokenId = splitTokenIdentifier(getTokenId(tokenInfo)).id;
 
       setIsLoading(true);
@@ -56,7 +61,8 @@ export const useTotalTokenAllowanceFromOrders = (
           provider,
           chainId,
           protocolFee,
-          tokenId
+          tokenId,
+          justifiedTakerTokenAddress
         );
         setTotalTokenAllowance(newTotalTokenAllowance);
       } catch (error) {

--- a/src/components/OverwriteLimitOrderNotice/OverwriteLimitOrderNotice.styles.tsx
+++ b/src/components/OverwriteLimitOrderNotice/OverwriteLimitOrderNotice.styles.tsx
@@ -1,0 +1,7 @@
+import styled from "styled-components/macro";
+
+export const ButtonsContainer = styled.div`
+  display: flex;
+  gap: 0.5rem;
+  margin-block-start: 0.75rem;
+`;

--- a/src/components/OverwriteLimitOrderNotice/OverwriteLimitOrderNotice.tsx
+++ b/src/components/OverwriteLimitOrderNotice/OverwriteLimitOrderNotice.tsx
@@ -1,0 +1,42 @@
+import { type FC, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { CompactActionButton } from "../../styled-components/CompactActionButton/CompactActionButton";
+import { Notice } from "../Notice/Notice";
+import { ButtonsContainer } from "./OverwriteLimitOrderNotice.styles";
+
+type OverwriteLimitOrderNoticeProps = {
+	className?: string;
+};
+
+export const OverwriteLimitOrderNotice: FC<OverwriteLimitOrderNoticeProps> = ({
+	className,
+}) => {
+	const [isHidden, setIsHidden] = useState(false);
+
+	const { t } = useTranslation();
+
+	const handleDismissButtonClick = () => {
+		setIsHidden(true);
+	};
+
+	if (isHidden) {
+		return null;
+	}
+
+	return (
+		<Notice
+			className={className}
+			text={
+				<>
+					{t("orders.overwriteLimitOrderWarning")}
+					{" "}
+					<ButtonsContainer>
+						<CompactActionButton onClick={handleDismissButtonClick}>
+							{t("orders.dismiss")}
+						</CompactActionButton>
+					</ButtonsContainer>
+				</>
+			}
+		/>
+	);
+};

--- a/src/components/OverwriteLimitOrderNotice/OverwriteLimitOrderNotice.tsx
+++ b/src/components/OverwriteLimitOrderNotice/OverwriteLimitOrderNotice.tsx
@@ -1,42 +1,42 @@
-import { type FC, useState } from "react";
+import { FC, useState } from "react";
 import { useTranslation } from "react-i18next";
+
 import { CompactActionButton } from "../../styled-components/CompactActionButton/CompactActionButton";
 import { Notice } from "../Notice/Notice";
 import { ButtonsContainer } from "./OverwriteLimitOrderNotice.styles";
 
 type OverwriteLimitOrderNoticeProps = {
-	className?: string;
+  className?: string;
 };
 
 export const OverwriteLimitOrderNotice: FC<OverwriteLimitOrderNoticeProps> = ({
-	className,
+  className,
 }) => {
-	const [isHidden, setIsHidden] = useState(false);
+  const [isHidden, setIsHidden] = useState(false);
 
-	const { t } = useTranslation();
+  const { t } = useTranslation();
 
-	const handleDismissButtonClick = () => {
-		setIsHidden(true);
-	};
+  const handleDismissButtonClick = () => {
+    setIsHidden(true);
+  };
 
-	if (isHidden) {
-		return null;
-	}
+  if (isHidden) {
+    return null;
+  }
 
-	return (
-		<Notice
-			className={className}
-			text={
-				<>
-					{t("orders.overwriteLimitOrderWarning")}
-					{" "}
-					<ButtonsContainer>
-						<CompactActionButton onClick={handleDismissButtonClick}>
-							{t("orders.dismiss")}
-						</CompactActionButton>
-					</ButtonsContainer>
-				</>
-			}
-		/>
-	);
+  return (
+    <Notice
+      className={className}
+      text={
+        <>
+          {t("orders.overwriteLimitOrderWarning")}{" "}
+          <ButtonsContainer>
+            <CompactActionButton onClick={handleDismissButtonClick}>
+              {t("orders.dismiss")}
+            </CompactActionButton>
+          </ButtonsContainer>
+        </>
+      }
+    />
+  );
 };

--- a/src/components/OverwriteLimitOrderNotice/hooks/useShouldShowOverwriteLimitOrderNotice.ts
+++ b/src/components/OverwriteLimitOrderNotice/hooks/useShouldShowOverwriteLimitOrderNotice.ts
@@ -1,0 +1,32 @@
+import { useAppSelector } from "../../../app/hooks";
+import type { AppTokenInfo } from "../../../entities/AppTokenInfo/AppTokenInfo";
+import { compareAddresses } from "../../../helpers/string";
+
+type ShouldShowOverwriteLimitOrderNoticeProps = {
+  chainId?: number;
+  makerTokenInfo: AppTokenInfo | null;
+  takerTokenInfo: AppTokenInfo | null;
+};
+
+export const useShouldShowOverwriteLimitOrderNotice = (
+  props: ShouldShowOverwriteLimitOrderNoticeProps
+) => {
+  const { chainId, makerTokenInfo, takerTokenInfo } = props;
+
+  const { delegateRules } = useAppSelector((state) => state.delegateRules);
+  console.log("delegateRules", delegateRules);
+
+  if (!chainId || !makerTokenInfo || !takerTokenInfo) {
+    return false;
+  }
+
+  const shouldShowOverwriteLimitOrderNotice = delegateRules.some(
+    (rule) =>
+      rule.expiry > Math.floor(new Date().getTime() / 1000) &&
+      rule.chainId === chainId &&
+      compareAddresses(rule.senderToken, makerTokenInfo.address) &&
+      compareAddresses(rule.signerToken, takerTokenInfo.address)
+  );
+
+  return shouldShowOverwriteLimitOrderNotice;
+};

--- a/src/components/OverwriteLimitOrderNotice/hooks/useShouldShowOverwriteLimitOrderNotice.ts
+++ b/src/components/OverwriteLimitOrderNotice/hooks/useShouldShowOverwriteLimitOrderNotice.ts
@@ -14,7 +14,6 @@ export const useShouldShowOverwriteLimitOrderNotice = (
   const { chainId, makerTokenInfo, takerTokenInfo } = props;
 
   const { delegateRules } = useAppSelector((state) => state.delegateRules);
-  console.log("delegateRules", delegateRules);
 
   if (!chainId || !makerTokenInfo || !takerTokenInfo) {
     return false;
@@ -24,6 +23,7 @@ export const useShouldShowOverwriteLimitOrderNotice = (
     (rule) =>
       rule.expiry > Math.floor(new Date().getTime() / 1000) &&
       rule.chainId === chainId &&
+      rule.senderFilledAmount !== rule.senderAmount &&
       compareAddresses(rule.senderToken, makerTokenInfo.address) &&
       compareAddresses(rule.signerToken, takerTokenInfo.address)
   );


### PR DESCRIPTION
Thing I noticed that's needed while testing.

- When calculating total approve amount of all limit orders, don't include orders with the pair of the new orders because it will be overwritten.
- Added warning when overwriting limit order

<img width="577" height="563" alt="Screenshot 2025-08-31 at 15 34 58" src="https://github.com/user-attachments/assets/e57f7dc2-fa4f-423a-b93e-084e616dc0a0" />
