### PR TITLE
Fix: Update GasNow API Endpoint for Sepolia

### DIFF
--- a/src/entities/GasPrice/GasPrice.ts
+++ b/src/entities/GasPrice/GasPrice.ts
@@ -5,26 +5,10 @@ export interface GasPriceDefisaverResource {
   cheap: number;
 }
 
-// https://sepolia.beaconcha.in/api/v1/execution/gasnow
-export interface GasPriceBeaconChaResource {
-  code: number;
-  data: {
-    rapid: number;
-    fast: number;
-    standard: number;
-    slow: number;
-    timestamp: number;
-    price: number;
-    priceUSD: number;
-  };
-}
-
-export enum GasPriceEndpointType {
-  beaconCha = "beaconCha",
-  defisaver = "defisaver",
-}
-
-export interface GasPriceEndpoint {
-  type: GasPriceEndpointType;
-  url: string;
+export interface GasPriceEtherscanResource {
+  LastBlock: string;
+  SafeGasPrice: string;
+  ProposeGasPrice: string;
+  FastGasPrice: string;
+  UsdPrice: string;
 }

--- a/src/entities/GasPrice/GasPriceHelpers.ts
+++ b/src/entities/GasPrice/GasPriceHelpers.ts
@@ -1,6 +1,6 @@
 import {
-  GasPriceBeaconChaResource,
   GasPriceDefisaverResource,
+  GasPriceEtherscanResource,
 } from "./GasPrice";
 
 export const isGasPriceDefisaverResource = (
@@ -12,15 +12,13 @@ export const isGasPriceDefisaverResource = (
   "regular" in resource &&
   "cheap" in resource;
 
-export const isGasPriceBeaconChaResource = (
+export const isGasPriceEtherscanResource = (
   resource: any
-): resource is GasPriceBeaconChaResource =>
+): resource is GasPriceEtherscanResource =>
   typeof resource === "object" &&
   resource !== null &&
-  "code" in resource &&
-  "data" in resource &&
-  "rapid" in resource.data &&
-  "fast" in resource.data &&
-  "standard" in resource.data &&
-  "slow" in resource.data &&
-  "timestamp" in resource.data;
+  "LastBlock" in resource &&
+  "SafeGasPrice" in resource &&
+  "ProposeGasPrice" in resource &&
+  "FastGasPrice" in resource &&
+  "UsdPrice" in resource;

--- a/src/entities/GasPrice/GasPriceService.ts
+++ b/src/entities/GasPrice/GasPriceService.ts
@@ -1,66 +1,64 @@
+import { ChainIds } from "@airswap/utils";
+
 import { BigNumber } from "bignumber.js";
 
-import { GasPriceEndpoint, GasPriceEndpointType } from "./GasPrice";
 import {
-  isGasPriceBeaconChaResource,
   isGasPriceDefisaverResource,
+  isGasPriceEtherscanResource,
 } from "./GasPriceHelpers";
 
-export const geDefisaverGasPriceApiCall = async (
-  url: string
-): Promise<BigNumber> => {
+const safeFallbackGasPrice = new BigNumber(0.004).dividedBy(10 ** 10);
+
+export const geDefisaverGasPriceApiCall = async (): Promise<BigNumber> => {
   try {
+    const url = "https://app.defisaver.com/api/gas-price/current";
     const response = await fetch(url);
     const data = await response.json();
 
     if (!response.ok || !isGasPriceDefisaverResource(data)) {
       console.error("[getMainnetGasPrice] Error in response", response);
 
-      return new BigNumber(0);
+      return safeFallbackGasPrice;
     }
 
     return new BigNumber(data.fast).dividedBy(10 ** 10);
   } catch (e: any) {
     console.error(
-      "[getMainnetGasPrice] Error getting gas price from ethgas.watch API: ",
+      "[geDefisaverGasPriceApiCall] Error getting gas price from ethgas.watch API: ",
       e.message
     );
 
-    return new BigNumber(0);
+    return safeFallbackGasPrice;
   }
 };
 
-export const getBeaconchaGasPriceApiCall = async (
-  url: string
+export const getEtherscanGasPriceApiCall = async (
+  _chainId: number
 ): Promise<BigNumber> => {
   try {
+    // Etherscan does not have Sepolia available, using BNB Chain as alternative.
+    const chainId = _chainId === ChainIds.SEPOLIA ? 56 : _chainId;
+    const url = `https://api.etherscan.io/v2/api?chainid=${chainId}&module=gastracker&action=gasoracle&apikey=${process.env.REACT_APP_ETHERSCAN_API_KEY}`;
     const response = await fetch(url);
     const data = await response.json();
+    const result = data.result;
 
-    if (!response.ok || !isGasPriceBeaconChaResource(data)) {
-      console.error("[getBeaconchaGasPrice] Error in response", response);
+    if (!response.ok || !isGasPriceEtherscanResource(result)) {
+      console.error(
+        "[getEtherscanGasPriceApiCall] Error in response",
+        response
+      );
 
-      return new BigNumber(0);
+      return safeFallbackGasPrice;
     }
 
-    return new BigNumber(data.data.fast).dividedBy(10 ** 18);
+    return new BigNumber(result.FastGasPrice).dividedBy(10 ** 10);
   } catch (e: any) {
     console.error(
-      "[getBeaconchaGasPrice] Error getting gas price from ethgas.watch API: ",
+      "[getEtherscanGasPriceApiCall] Error getting gas price from ethgas.watch API: ",
       e.message
     );
 
-    return new BigNumber(0);
+    return safeFallbackGasPrice;
   }
-};
-
-export const getGasPriceApiCall = async (
-  url: string,
-  type: GasPriceEndpointType
-): Promise<BigNumber> => {
-  if (type === GasPriceEndpointType.defisaver) {
-    return geDefisaverGasPriceApiCall(url);
-  }
-
-  return getBeaconchaGasPriceApiCall(url);
 };

--- a/src/features/gasCost/gasCostApi.ts
+++ b/src/features/gasCost/gasCostApi.ts
@@ -5,27 +5,15 @@ import { BigNumber } from "bignumber.js";
 import { Contract, providers, BigNumber as EthersBigNumber } from "ethers";
 
 import {
-  GasPriceEndpoint,
-  GasPriceEndpointType,
-} from "../../entities/GasPrice/GasPrice";
-import { getGasPriceApiCall } from "../../entities/GasPrice/GasPriceService";
+  geDefisaverGasPriceApiCall,
+  getEtherscanGasPriceApiCall,
+} from "../../entities/GasPrice/GasPriceService";
 import getWethAddress from "../../helpers/getWethAddress";
 import uniswapFactoryAbi from "../../uniswap/abis/factory.json";
 import uniswapPairAbi from "../../uniswap/abis/pair.json";
 import uniswapDeploys from "../../uniswap/deployments";
 
 export const gasUsedPerSwap = 185555;
-
-const endpoints: Partial<Record<ChainIds, GasPriceEndpoint>> = {
-  [ChainIds.MAINNET]: {
-    type: GasPriceEndpointType.defisaver,
-    url: "https://app.defisaver.com/api/gas-price/current",
-  },
-  [ChainIds.SEPOLIA]: {
-    type: GasPriceEndpointType.beaconCha,
-    url: "https://sepolia.beaconcha.in/api/v1/execution/gasnow",
-  },
-};
 
 interface GetGasPriceResponse {
   gasPrice: string;
@@ -36,16 +24,10 @@ export const getGasPrice = createAsyncThunk<
   GetGasPriceResponse,
   { chainId: ChainIds }
 >("gasPrice/getGasPrice", async ({ chainId }) => {
-  const endpoint = endpoints[chainId];
-
-  if (!endpoint) {
-    return {
-      gasPrice: "0",
-      swapTransactionCost: "0",
-    };
-  }
-
-  const gasPrice = await getGasPriceApiCall(endpoint.url, endpoint.type);
+  // Use Defisaver for Mainnet since it has been very reliable, use etherscan for everything else.
+  const gasPrice = await (chainId === ChainIds.MAINNET
+    ? geDefisaverGasPriceApiCall()
+    : getEtherscanGasPriceApiCall(chainId));
   const swapTransactionCost = new BigNumber(gasPrice).multipliedBy(
     gasUsedPerSwap
   );


### PR DESCRIPTION
Fixes #1040 

Solved by replacing beaconcha with etherscan API. Sepolia is not available but decided to fallback to BNB chain so we're at least working with real data.