### PR TITLE
Added fix for token image placeholder when taking limit order

### DIFF
--- a/src/components/TokenSelect/TokenSelect.styles.tsx
+++ b/src/components/TokenSelect/TokenSelect.styles.tsx
@@ -272,7 +272,8 @@ export const TokenSelectContainer = styled.div<{
   }
 
   ${ContainingButton} ${StyledTokenLogo} {
-    ${(props) => (props.showTokenContractLink ? "visibility: hidden" : "")};
+    ${(props) =>
+      props.isQuote && props.showTokenContractLink ? "visibility: hidden" : ""};
   }
 
   ${TokenLogoLeft} {


### PR DESCRIPTION
Fixes #1091 

<img width="668" height="614" alt="Screenshot 2025-10-21 at 19 43 43" src="https://github.com/user-attachments/assets/21c32862-c0bd-4c5c-91c1-cf188c5ca62b" />
